### PR TITLE
Add optional weight array support to fromCSR()

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -157,6 +157,10 @@ protected:
     //!< Arrow array for CSR indptr (offsets into indices array) for incoming edges - only for
     //!< directed graphs
     std::shared_ptr<arrow::UInt64Array> inEdgesCSRIndptr;
+    //!< Arrow array for CSR edge weights for outgoing edges
+    std::shared_ptr<arrow::DoubleArray> outEdgesCSRWeights;
+    //!< Arrow array for CSR edge weights for incoming edges - only for directed graphs
+    std::shared_ptr<arrow::DoubleArray> inEdgesCSRWeights;
     //!< flag to indicate if CSR arrays are being used instead of vectors
     bool usingCSR;
 
@@ -754,7 +758,8 @@ public:
           directed(other.directed), edgesIndexed(other.edgesIndexed), deletedID(other.deletedID),
           exists(other.exists), outEdgesCSRIndices(other.outEdgesCSRIndices),
           outEdgesCSRIndptr(other.outEdgesCSRIndptr), inEdgesCSRIndices(other.inEdgesCSRIndices),
-          inEdgesCSRIndptr(other.inEdgesCSRIndptr), usingCSR(other.usingCSR),
+          inEdgesCSRIndptr(other.inEdgesCSRIndptr), outEdgesCSRWeights(other.outEdgesCSRWeights),
+          inEdgesCSRWeights(other.inEdgesCSRWeights), usingCSR(other.usingCSR),
           // call special constructors to copy attribute maps
           nodeAttributeMap(other.nodeAttributeMap, this),
           edgeAttributeMap(other.edgeAttributeMap, this) {
@@ -779,7 +784,8 @@ protected:
           directed(other.directed), edgesIndexed(other.edgesIndexed), deletedID(other.deletedID),
           exists(other.exists), outEdgesCSRIndices(other.outEdgesCSRIndices),
           outEdgesCSRIndptr(other.outEdgesCSRIndptr), inEdgesCSRIndices(other.inEdgesCSRIndices),
-          inEdgesCSRIndptr(other.inEdgesCSRIndptr), usingCSR(other.usingCSR),
+          inEdgesCSRIndptr(other.inEdgesCSRIndptr), outEdgesCSRWeights(other.outEdgesCSRWeights),
+          inEdgesCSRWeights(other.inEdgesCSRWeights), usingCSR(other.usingCSR),
           // call special constructors to copy attribute maps
           nodeAttributeMap(other.nodeAttributeMap, this),
           edgeAttributeMap(other.edgeAttributeMap, this) {
@@ -796,7 +802,9 @@ public:
           exists(std::move(other.exists)), outEdgesCSRIndices(std::move(other.outEdgesCSRIndices)),
           outEdgesCSRIndptr(std::move(other.outEdgesCSRIndptr)),
           inEdgesCSRIndices(std::move(other.inEdgesCSRIndices)),
-          inEdgesCSRIndptr(std::move(other.inEdgesCSRIndptr)), usingCSR(other.usingCSR),
+          inEdgesCSRIndptr(std::move(other.inEdgesCSRIndptr)),
+          outEdgesCSRWeights(std::move(other.outEdgesCSRWeights)),
+          inEdgesCSRWeights(std::move(other.inEdgesCSRWeights)), usingCSR(other.usingCSR),
           nodeAttributeMap(std::move(other.nodeAttributeMap)),
           edgeAttributeMap(std::move(other.edgeAttributeMap)) {
         // attributes: set graph pointer to this new graph
@@ -816,11 +824,16 @@ public:
      * directed graphs).
      * @param inIndptr Arrow array containing offsets into inIndices for each node (only for
      * directed graphs).
+     * @param outWeights Arrow array containing edge weights for outgoing edges (optional).
+     * @param inWeights Arrow array containing edge weights for incoming edges (optional, only for
+     * directed graphs).
      */
     Graph(count n, bool directed, std::shared_ptr<arrow::UInt64Array> outIndices,
           std::shared_ptr<arrow::UInt64Array> outIndptr,
           std::shared_ptr<arrow::UInt64Array> inIndices = nullptr,
-          std::shared_ptr<arrow::UInt64Array> inIndptr = nullptr);
+          std::shared_ptr<arrow::UInt64Array> inIndptr = nullptr,
+          std::shared_ptr<arrow::DoubleArray> outWeights = nullptr,
+          std::shared_ptr<arrow::DoubleArray> inWeights = nullptr);
 
     /** move assignment operator */
     Graph &operator=(Graph &&other) noexcept {
@@ -839,6 +852,8 @@ public:
         std::swap(outEdgesCSRIndptr, other.outEdgesCSRIndptr);
         std::swap(inEdgesCSRIndices, other.inEdgesCSRIndices);
         std::swap(inEdgesCSRIndptr, other.inEdgesCSRIndptr);
+        std::swap(outEdgesCSRWeights, other.outEdgesCSRWeights);
+        std::swap(inEdgesCSRWeights, other.inEdgesCSRWeights);
         std::swap(deletedID, other.deletedID);
 
         // attributes: set graph pointer to this new graph

--- a/include/networkit/graph/GraphR.hpp
+++ b/include/networkit/graph/GraphR.hpp
@@ -51,13 +51,18 @@ public:
      * directed graphs).
      * @param inIndptr Arrow array containing offsets into inIndices for each node (only for
      * directed graphs).
+     * @param outWeights Arrow array containing edge weights for outgoing edges (optional).
+     * @param inWeights Arrow array containing edge weights for incoming edges (optional, only for
+     * directed graphs).
      */
     GraphR(count n, bool directed, std::shared_ptr<arrow::UInt64Array> outIndices,
            std::shared_ptr<arrow::UInt64Array> outIndptr,
            std::shared_ptr<arrow::UInt64Array> inIndices = nullptr,
-           std::shared_ptr<arrow::UInt64Array> inIndptr = nullptr)
+           std::shared_ptr<arrow::UInt64Array> inIndptr = nullptr,
+           std::shared_ptr<arrow::DoubleArray> outWeights = nullptr,
+           std::shared_ptr<arrow::DoubleArray> inWeights = nullptr)
         : Graph(n, directed, std::move(outIndices), std::move(outIndptr), std::move(inIndices),
-                std::move(inIndptr)) {}
+                std::move(inIndptr), std::move(outWeights), std::move(inWeights)) {}
 
     /**
      * Copy constructor
@@ -96,7 +101,8 @@ public:
 
     /**
      * Return edge weight of edge {@a u,@a v}. Returns 0 if edge does not
-     * exist. For CSR graphs, always returns 1.0 if edge exists (unweighted).
+     * exist. If weights are provided during construction, returns the actual
+     * edge weight; otherwise returns defaultEdgeWeight (1.0).
      *
      * @param u Endpoint of edge.
      * @param v Endpoint of edge.

--- a/include/networkit/graph/GraphW.hpp
+++ b/include/networkit/graph/GraphW.hpp
@@ -96,6 +96,8 @@ public:
         outEdgesCSRIndptr.reset();
         inEdgesCSRIndices.reset();
         inEdgesCSRIndptr.reset();
+        outEdgesCSRWeights.reset();
+        inEdgesCSRWeights.reset();
         usingCSR = false;
     }
 

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -15,6 +15,8 @@ from .structures cimport edgeid, index, count, node, edgeweight
 cdef extern from "arrow/api.h" namespace "arrow":
 	cdef cppclass UInt64Array:
 		pass
+	cdef cppclass DoubleArray:
+		pass
 	cdef cppclass CArray "arrow::Array":
 		pass
 
@@ -155,7 +157,7 @@ cdef extern from "<networkit/graph/GraphW.hpp>":
 cdef extern from "<networkit/graph/GraphR.hpp>":
 	cdef cppclass _GraphR "NetworKit::GraphR" (_Graph):
 		_GraphR(count n, bool_t directed, vector[node] outIndices, vector[index] outIndptr, vector[node] inIndices, vector[index] inIndptr) except +
-		_GraphR(count n, bool_t directed, shared_ptr[UInt64Array] outIndices, shared_ptr[UInt64Array] outIndptr, shared_ptr[UInt64Array] inIndices, shared_ptr[UInt64Array] inIndptr) except +
+		_GraphR(count n, bool_t directed, shared_ptr[UInt64Array] outIndices, shared_ptr[UInt64Array] outIndptr, shared_ptr[UInt64Array] inIndices, shared_ptr[UInt64Array] inIndptr, shared_ptr[DoubleArray] outWeights, shared_ptr[DoubleArray] inWeights) except +
 		_GraphR(const _GraphR& other) except +
 
 cdef extern from "<networkit/graph/Graph.hpp>":


### PR DESCRIPTION
- Add out_weights and in_weights parameters to Graph::fromCSR()
- Update C++ Graph, GraphR constructors to accept Arrow DoubleArray for weights
- Update GraphR weight methods (weight(), getIthNeighborWeight(), etc.) to use actual weights
- Update GraphW copy constructor to reset weight array pointers
- Update Cython declarations in graph.pxd for DoubleArray type
- Update Python fromCSR() to accept and convert weight Arrow arrays

Weights default to 1.0 when not provided, maintaining backward compatibility.