### PR TITLE
fix: correct forInEdgesOf callback parameter ordering to fix race con…

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -1754,16 +1754,11 @@ inline void Graph::forInEdgesOfImpl(node u, L handle) const {
         // Check exists for mutable graphs
         if (!exists[u])
             return;
-        // Create a wrapper function that swaps the first two arguments
-        // The handle expects (source, target, ...) but virtual method provides (target, source,
-        // ...)
-        auto wrapper = std::function<void(node, node, edgeweight, edgeid)>(
-            [&](node target, node source, edgeweight w, edgeid e) {
-                // Swap arguments: call handle with (source, target, ...) instead of (target,
-                // source, ...)
-                edgeLambda(handle, source, target, w, e);
-            });
-        forInEdgesVirtualImpl(u, graphIsDirected, hasWeights, graphHasEdgeIds, wrapper);
+        // GraphW's forInEdgesVirtualImpl calls handle(v, u, ...) where v is source and u is target
+        // This matches our expected signature of (source, target, ...), so no swap needed
+        forInEdgesVirtualImpl(
+            u, graphIsDirected, hasWeights, graphHasEdgeIds,
+            [&](node v, node u, edgeweight w, edgeid e) { edgeLambda(handle, v, u, w, e); });
     }
 }
 

--- a/networkit/cpp/centrality/EigenvectorCentrality.cpp
+++ b/networkit/cpp/centrality/EigenvectorCentrality.cpp
@@ -33,8 +33,11 @@ void EigenvectorCentrality::run() {
         // iterate matrix-vector product
         G.parallelForNodes([&](node u) {
             values[u] = 0.0;
-            G.forInEdgesOf(u,
-                           [&](node u, node v, edgeweight ew) { values[u] += ew * scoreData[v]; });
+            G.forInEdgesOf(u, [&](node v, node /* target_u */, edgeweight ew) {
+                // forInEdgesOf callback receives (source, target, weight, eid)
+                // where target is u and source is v
+                values[u] += ew * scoreData[v];
+            });
         });
 
         // normalize values

--- a/networkit/cpp/centrality/PageRank.cpp
+++ b/networkit/cpp/centrality/PageRank.cpp
@@ -67,10 +67,12 @@ void PageRank::run() {
         handler.assureRunning();
         G.balancedParallelForNodes([&](const node u) {
             pr[u] = 0.0;
-            G.forInEdgesOf(u, [&](const node u, const node v, const edgeweight w) {
+            G.forInEdgesOf(u, [&](const node v, const node /* target_u */, const edgeweight w) {
                 // note: inconsistency in definition in Newman's book (Ch. 7) regarding directed
                 // graphs we follow the verbal description, which requires to sum over the incoming
                 // edges
+                // forInEdgesOf callback receives (source, target, weight, eid)
+                // where target is u (the node we're iterating for) and source is v
                 pr[u] += scoreData[v] * w / deg[v];
             });
             pr[u] *= damp;

--- a/networkit/test/test_arrow_pagerank.py
+++ b/networkit/test/test_arrow_pagerank.py
@@ -143,7 +143,7 @@ def test_small_graph():
     
     return graph
 
-def test_pagerank_algorithm(graph):
+def run_pagerank_algorithm(graph):
     """Test PageRank algorithm on the graph."""
     print("\n=== Testing PageRank Algorithm ===")
     
@@ -211,7 +211,7 @@ def test_larger_graph():
     graph = create_graph_arrow_optimized(df_arrow, directed=False)
     
     # Run PageRank
-    success = test_pagerank_algorithm(graph)
+    success = run_pagerank_algorithm(graph)
     
     return graph, success
 
@@ -223,7 +223,7 @@ def main():
     try:
         # Test 1: Small graph
         small_graph = test_small_graph()
-        small_success = test_pagerank_algorithm(small_graph)
+        small_success = run_pagerank_algorithm(small_graph)
         
         # Test 2: Larger graph
         large_graph, large_success = test_larger_graph()


### PR DESCRIPTION
…dition

The forInEdgesOf callback receives (source, target, weight, eid) but PageRank and EigenvectorCentrality were using parameter names (u, v) which shadowed the outer scope variable u. This caused multiple threads to write to the same array element, creating a race condition that prevented convergence with OMP_NUM_THREADS >= 4.

Changes:
- PageRank.cpp: Fix lambda parameter names in forInEdgesOf callback
- EigenvectorCentrality.cpp: Fix lambda parameter names in forInEdgesOf callback
- Graph.hpp: Remove incorrect parameter swapping in forInEdgesOfImpl for GraphW
- test_arrow_pagerank.py: Rename test function to avoid pytest collection warning

The fix ensures thread-safe writes and deterministic results across all thread counts. Verified with tests using 1, 2, 4, 8, and 12 threads.