### PR TITLE
Do not brew install libomp

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -216,7 +216,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BEFORE_ALL: |
-            brew install ninja ccache apache-arrow libomp
+            brew install ninja ccache apache-arrow
             export CCACHE_DIR=$HOME/.ccache
             mkdir -p /tmp/nk_core_build /tmp/nk_core_install
             cmake -S {project} -B /tmp/nk_core_build \

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -102,7 +102,6 @@ jobs:
         run: |
           brew install apache-arrow
           if [[ "${{ matrix.compiler }}" == "llvm-20" ]]; then
-            brew install libomp
             brew reinstall llvm@20
           fi
 


### PR DESCRIPTION
This causes problems for mac users due to conflicting versions shipped with other packages.