### PR TITLE
Parallel Leiden scoring extension

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -88,7 +88,7 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
           sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
           sudo apt-get update
-          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev
+          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev=23.0.1-1
 
       - name: Install prerequisites (Linux)
         if: matrix.os == 'linux' && matrix.compiler == 'gcc-14'
@@ -96,7 +96,7 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
           sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
           sudo apt-get update
-          sudo apt-get install -y g++-14 ninja-build libarrow-dev
+          sudo apt-get install -y g++-14 ninja-build libarrow-dev=23.0.1-1
 
       - name: Install prerequisites (macOS)
         if: matrix.os == 'macos'

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ CTestTestfile.cmake
 
 ### MacOS
 .DS_Store
+
+### uv
+uv.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,9 @@ if(NETWORKIT_BUILD_CORE AND NETWORKIT_MONOLITH)
 	endif()
 
 	target_link_libraries(networkit PRIVATE OpenMP::OpenMP_CXX PUBLIC tlx Arrow::arrow_shared)
+	if(CMAKE_DL_LIBS)
+		target_link_libraries(networkit PRIVATE ${CMAKE_DL_LIBS})
+	endif()
 
 	set_target_properties(networkit PROPERTIES
 			CXX_STANDARD ${NETWORKIT_CXX_STANDARD}

--- a/examples/parallel_leiden_scoring_extension_demo.py
+++ b/examples/parallel_leiden_scoring_extension_demo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+
+import networkit as nk
+
+
+def build_demo_graph():
+    graph = nk.Graph(6, weighted=False, directed=False)
+    for u, v in [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5), (2, 3)]:
+        graph.addEdge(u, v)
+    return graph
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Demo ParallelLeidenView's shared-library move scoring extension mechanism."
+    )
+    parser.add_argument(
+        "--plugin",
+        type=Path,
+        help=(
+            "Path to a scorer shared library. "
+            "Example: build/networkit/cpp/community/libnetworkit_parallel_leiden_modularity_extension.dylib"
+        ),
+    )
+    parser.add_argument(
+        "--use-env",
+        action="store_true",
+        help="Load the plugin through NETWORKIT_LEIDEN_MOVE_SCORING_LIB instead of the Python API.",
+    )
+    parser.add_argument("--iterations", type=int, default=2, help="Number of Leiden iterations.")
+    parser.add_argument("--gamma", type=float, default=1.0, help="Resolution parameter.")
+    parser.add_argument(
+        "--randomize",
+        action="store_true",
+        help="Randomize node order. Disabled by default to keep output stable.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    graph = build_demo_graph()
+    plugin_loaded_via = None
+
+    if args.use_env:
+        if args.plugin is None:
+            raise SystemExit("--use-env requires --plugin")
+        os.environ["NETWORKIT_LEIDEN_MOVE_SCORING_LIB"] = str(args.plugin.resolve())
+        plugin_loaded_via = "env"
+
+    leiden = nk.community.ParallelLeidenView(
+        graph, iterations=args.iterations, randomize=args.randomize, gamma=args.gamma
+    )
+
+    if args.plugin is not None and not args.use_env:
+        if hasattr(leiden, "loadMoveScoringExtension"):
+            leiden.loadMoveScoringExtension(str(args.plugin.resolve()))
+            plugin_loaded_via = "api"
+        else:
+            # Fallback for older Python extension builds where the C++ env hook exists
+            # but the wrapper method has not been rebuilt yet.
+            os.environ["NETWORKIT_LEIDEN_MOVE_SCORING_LIB"] = str(args.plugin.resolve())
+            leiden = nk.community.ParallelLeidenView(
+                graph, iterations=args.iterations, randomize=args.randomize, gamma=args.gamma
+            )
+            plugin_loaded_via = "env-fallback"
+
+    leiden.run()
+    partition = leiden.getPartition()
+
+    print("communities:", partition.numberOfSubsets())
+    print("assignment:", [partition[i] for i in range(graph.numberOfNodes())])
+    if args.plugin is None:
+        print("scorer: built-in modularity")
+    elif plugin_loaded_via == "api":
+        print("scorer: plugin loaded via ParallelLeidenView.loadMoveScoringExtension()")
+    elif plugin_loaded_via == "env":
+        print("scorer: plugin loaded from NETWORKIT_LEIDEN_MOVE_SCORING_LIB")
+    elif plugin_loaded_via == "env-fallback":
+        print("scorer: plugin loaded from NETWORKIT_LEIDEN_MOVE_SCORING_LIB")
+        print("note: Python wrapper method not available in this build, used env fallback")
+    else:
+        print("scorer: plugin requested, but no loading path was used")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/networkit/community/ParallelLeidenScoringExtension.hpp
+++ b/include/networkit/community/ParallelLeidenScoringExtension.hpp
@@ -12,8 +12,8 @@
 namespace NetworKit {
 
 using ParallelLeidenCommunityScoreFunction =
-    double (*)(double cutWeight, double degree, double communityVolume, count communitySize,
-               double gamma, double inverseGraphVolume);
+    double (*)(double cutWeight, double degree, double communityVolume, count subsetSize,
+               count communitySize, double gamma, double inverseGraphVolume);
 
 using ParallelLeidenRefineSetConditionFunction =
     bool (*)(double cutWeight, double subsetVolume, count subsetSize, double targetVolume,
@@ -28,6 +28,7 @@ extern "C" {
  * Required: score a candidate community during the move phase.
  */
 double networkitParallelLeidenCommunityScore(double cutWeight, double degree, double communityVolume,
+                                             NetworKit::count subsetSize,
                                              NetworKit::count communitySize, double gamma,
                                              double inverseGraphVolume);
 
@@ -37,6 +38,7 @@ double networkitParallelLeidenCommunityScore(double cutWeight, double degree, do
  */
 double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
                                                         double communityVolume,
+                                                        NetworKit::count subsetSize,
                                                         NetworKit::count communitySize,
                                                         double gamma,
                                                         double inverseGraphVolume);

--- a/include/networkit/community/ParallelLeidenScoringExtension.hpp
+++ b/include/networkit/community/ParallelLeidenScoringExtension.hpp
@@ -7,10 +7,17 @@
 #ifndef NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_SCORING_EXTENSION_HPP_
 #define NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_SCORING_EXTENSION_HPP_
 
+#include <networkit/Globals.hpp>
+
 namespace NetworKit {
 
 using ParallelLeidenCommunityScoreFunction =
-    double (*)(double cutWeight, double degree, double communityVolume, double gamma,
+    double (*)(double cutWeight, double degree, double communityVolume, count communitySize,
+               double gamma, double inverseGraphVolume);
+
+using ParallelLeidenRefineSetConditionFunction =
+    bool (*)(double cutWeight, double subsetVolume, count subsetSize, double targetVolume,
+             count targetSize, double sourceVolume, count sourceSize, double gamma,
                double inverseGraphVolume);
 
 } // namespace NetworKit
@@ -21,14 +28,37 @@ extern "C" {
  * Required: score a candidate community during the move phase.
  */
 double networkitParallelLeidenCommunityScore(double cutWeight, double degree, double communityVolume,
-                                             double gamma, double inverseGraphVolume);
+                                             NetworKit::count communitySize, double gamma,
+                                             double inverseGraphVolume);
 
 /**
  * Optional: override the current-community stay threshold used to accept or reject the best move.
  * When omitted, ParallelLeidenView falls back to the built-in modularity threshold.
  */
 double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
-                                                        double communityVolume, double gamma,
+                                                        double communityVolume,
+                                                        NetworKit::count communitySize,
+                                                        double gamma,
+                                                        double inverseGraphVolume);
+
+/**
+ * Optional: override the refine-phase R-set condition.
+ * When omitted, ParallelLeidenView falls back to the built-in modularity condition.
+ */
+bool networkitParallelLeidenRefineRSetCondition(double cutWeight, double subsetVolume,
+                                                NetworKit::count subsetSize, double targetVolume,
+                                                NetworKit::count targetSize, double sourceVolume,
+                                                NetworKit::count sourceSize, double gamma,
+                                                double inverseGraphVolume);
+
+/**
+ * Optional: override the refine-phase T-set condition.
+ * When omitted, ParallelLeidenView falls back to the built-in modularity condition.
+ */
+bool networkitParallelLeidenRefineTSetCondition(double cutWeight, double subsetVolume,
+                                                NetworKit::count subsetSize, double targetVolume,
+                                                NetworKit::count targetSize, double sourceVolume,
+                                                NetworKit::count sourceSize, double gamma,
                                                         double inverseGraphVolume);
 
 } // extern "C"

--- a/include/networkit/community/ParallelLeidenScoringExtension.hpp
+++ b/include/networkit/community/ParallelLeidenScoringExtension.hpp
@@ -1,0 +1,36 @@
+/*
+ * ParallelLeidenScoringExtension.hpp
+ *
+ *  Shared-library ABI for custom ParallelLeidenView move scoring metrics.
+ */
+
+#ifndef NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_SCORING_EXTENSION_HPP_
+#define NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_SCORING_EXTENSION_HPP_
+
+namespace NetworKit {
+
+using ParallelLeidenCommunityScoreFunction =
+    double (*)(double cutWeight, double degree, double communityVolume, double gamma,
+               double inverseGraphVolume);
+
+} // namespace NetworKit
+
+extern "C" {
+
+/**
+ * Required: score a candidate community during the move phase.
+ */
+double networkitParallelLeidenCommunityScore(double cutWeight, double degree, double communityVolume,
+                                             double gamma, double inverseGraphVolume);
+
+/**
+ * Optional: override the current-community stay threshold used to accept or reject the best move.
+ * When omitted, ParallelLeidenView falls back to the built-in modularity threshold.
+ */
+double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
+                                                        double communityVolume, double gamma,
+                                                        double inverseGraphVolume);
+
+} // extern "C"
+
+#endif // NETWORKIT_COMMUNITY_PARALLEL_LEIDEN_SCORING_EXTENSION_HPP_

--- a/include/networkit/community/ParallelLeidenView.hpp
+++ b/include/networkit/community/ParallelLeidenView.hpp
@@ -99,15 +99,17 @@ private:
     static count nodeSize(const CoarsenedGraphView &graph, node u);
 
     static double modularityCommunityScore(double cutD, double degreeV, double volD,
-                                           count sizeD, double gamma,
+                                           count subsetSize, count sizeD, double gamma,
                                            double inverseGraphVolume) {
+        tlx::unused(subsetSize);
         tlx::unused(sizeD);
         return cutD - gamma * degreeV * volD * inverseGraphVolume;
     }
 
-    static double modularityThresholdScore(double cutC, double degreeV, double volC, count sizeC,
-                                           double gamma,
+    static double modularityThresholdScore(double cutC, double degreeV, double volC,
+                                           count subsetSize, count sizeC, double gamma,
                                            double inverseGraphVolume) {
+        tlx::unused(subsetSize);
         tlx::unused(sizeC);
         return cutC - gamma * (volC - degreeV) * degreeV * inverseGraphVolume;
     }
@@ -137,15 +139,15 @@ private:
     }
 
     inline double scoreCommunity(double cutWeight, double degree, double communityVolume,
-                                 count communitySize) const {
-        return communityScoreFunction_(cutWeight, degree, communityVolume, communitySize, gamma,
-                                       inverseGraphVolume);
+                                 count subsetSize, count communitySize) const {
+        return communityScoreFunction_(cutWeight, degree, communityVolume, subsetSize,
+                                       communitySize, gamma, inverseGraphVolume);
     }
 
     inline double scoreCurrentCommunityThreshold(double cutWeight, double degree,
-                                                 double communityVolume,
+                                                 double communityVolume, count subsetSize,
                                                  count communitySize) const {
-        return currentCommunityThresholdFunction_(cutWeight, degree, communityVolume,
+        return currentCommunityThresholdFunction_(cutWeight, degree, communityVolume, subsetSize,
                                                   communitySize, gamma, inverseGraphVolume);
     }
 

--- a/include/networkit/community/ParallelLeidenView.hpp
+++ b/include/networkit/community/ParallelLeidenView.hpp
@@ -14,6 +14,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <omp.h>
 #include <thread>
 #include <tlx/unused.hpp>
@@ -27,6 +28,7 @@
 #include <networkit/community/CommunityDetectionAlgorithm.hpp>
 #include <networkit/community/Modularity.hpp>
 #include <networkit/community/PLM.hpp>
+#include <networkit/community/ParallelLeidenScoringExtension.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/structures/Partition.hpp>
 
@@ -59,6 +61,17 @@ public:
 
     void run() override;
 
+    /**
+     * Load a shared library that customizes the move-phase scoring metric.
+     *
+     * The library must export `networkitParallelLeidenCommunityScore`. It may additionally export
+     * `networkitParallelLeidenCurrentCommunityThreshold` to replace the default modularity-based
+     * stay threshold as well.
+     */
+    void loadMoveScoringExtension(const std::string &sharedLibraryPath);
+
+    void unloadMoveScoringExtension();
+
     int VECTOR_OVERSIZE = 10000;
 
 private:
@@ -81,12 +94,25 @@ private:
     template <typename GraphType>
     Partition parallelRefine(const GraphType &graph);
 
-    inline double modularityDelta(double cutD, double degreeV, double volD) const {
+    static double modularityCommunityScore(double cutD, double degreeV, double volD, double gamma,
+                                           double inverseGraphVolume) {
         return cutD - gamma * degreeV * volD * inverseGraphVolume;
-    };
+    }
 
-    inline double modularityThreshold(double cutC, double volC, double degreeV) const {
+    static double modularityThresholdScore(double cutC, double degreeV, double volC, double gamma,
+                                           double inverseGraphVolume) {
         return cutC - gamma * (volC - degreeV) * degreeV * inverseGraphVolume;
+    }
+
+    inline double scoreCommunity(double cutWeight, double degree, double communityVolume) const {
+        return communityScoreFunction_(cutWeight, degree, communityVolume, gamma,
+                                       inverseGraphVolume);
+    }
+
+    inline double scoreCurrentCommunityThreshold(double cutWeight, double degree,
+                                                 double communityVolume) const {
+        return currentCommunityThresholdFunction_(cutWeight, degree, communityVolume, gamma,
+                                                  inverseGraphVolume);
     }
 
     static inline void lockLowerFirst(index a, index b, std::vector<std::mutex> &locks) {
@@ -131,6 +157,12 @@ private:
     // Optional convergence stop: minimum relative reduction in community count per inner iter.
     // 0.0 disables this criterion.
     double minCommunityReduction = 0.0;
+
+    void *scoringExtensionHandle_ = nullptr;
+    ParallelLeidenCommunityScoreFunction communityScoreFunction_ = &modularityCommunityScore;
+    ParallelLeidenCommunityScoreFunction currentCommunityThresholdFunction_ =
+        &modularityThresholdScore;
+    std::string scoringExtensionPath_;
 };
 
 } // namespace NetworKit

--- a/include/networkit/community/ParallelLeidenView.hpp
+++ b/include/networkit/community/ParallelLeidenView.hpp
@@ -94,25 +94,75 @@ private:
     template <typename GraphType>
     Partition parallelRefine(const GraphType &graph);
 
-    static double modularityCommunityScore(double cutD, double degreeV, double volD, double gamma,
+    static count nodeSize(const Graph &graph, node u);
+
+    static count nodeSize(const CoarsenedGraphView &graph, node u);
+
+    static double modularityCommunityScore(double cutD, double degreeV, double volD,
+                                           count sizeD, double gamma,
                                            double inverseGraphVolume) {
+        tlx::unused(sizeD);
         return cutD - gamma * degreeV * volD * inverseGraphVolume;
     }
 
-    static double modularityThresholdScore(double cutC, double degreeV, double volC, double gamma,
+    static double modularityThresholdScore(double cutC, double degreeV, double volC, count sizeC,
+                                           double gamma,
                                            double inverseGraphVolume) {
+        tlx::unused(sizeC);
         return cutC - gamma * (volC - degreeV) * degreeV * inverseGraphVolume;
     }
 
-    inline double scoreCommunity(double cutWeight, double degree, double communityVolume) const {
-        return communityScoreFunction_(cutWeight, degree, communityVolume, gamma,
+    static bool modularityRefineRSetCondition(double cutWeight, double subsetVolume,
+                                              count subsetSize, double targetVolume,
+                                              count targetSize, double sourceVolume,
+                                              count sourceSize, double gamma,
+                                              double inverseGraphVolume) {
+        tlx::unused(subsetSize);
+        tlx::unused(targetSize);
+        tlx::unused(sourceVolume);
+        tlx::unused(sourceSize);
+        return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
+    }
+
+    static bool modularityRefineTSetCondition(double cutWeight, double subsetVolume,
+                                              count subsetSize, double targetVolume,
+                                              count targetSize, double sourceVolume,
+                                              count sourceSize, double gamma,
+                                              double inverseGraphVolume) {
+        tlx::unused(subsetSize);
+        tlx::unused(targetSize);
+        tlx::unused(sourceVolume);
+        tlx::unused(sourceSize);
+        return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
+    }
+
+    inline double scoreCommunity(double cutWeight, double degree, double communityVolume,
+                                 count communitySize) const {
+        return communityScoreFunction_(cutWeight, degree, communityVolume, communitySize, gamma,
                                        inverseGraphVolume);
     }
 
     inline double scoreCurrentCommunityThreshold(double cutWeight, double degree,
-                                                 double communityVolume) const {
-        return currentCommunityThresholdFunction_(cutWeight, degree, communityVolume, gamma,
-                                                  inverseGraphVolume);
+                                                 double communityVolume,
+                                                 count communitySize) const {
+        return currentCommunityThresholdFunction_(cutWeight, degree, communityVolume,
+                                                  communitySize, gamma, inverseGraphVolume);
+    }
+
+    inline bool refineRSetCondition(double cutWeight, double subsetVolume, count subsetSize,
+                                    double targetVolume, count targetSize, double sourceVolume,
+                                    count sourceSize) const {
+        return refineRSetConditionFunction_(cutWeight, subsetVolume, subsetSize, targetVolume,
+                                            targetSize, sourceVolume, sourceSize, gamma,
+                                            inverseGraphVolume);
+    }
+
+    inline bool refineTSetCondition(double cutWeight, double subsetVolume, count subsetSize,
+                                    double targetVolume, count targetSize, double sourceVolume,
+                                    count sourceSize) const {
+        return refineTSetConditionFunction_(cutWeight, subsetVolume, subsetSize, targetVolume,
+                                            targetSize, sourceVolume, sourceSize, gamma,
+                                            inverseGraphVolume);
     }
 
     static inline void lockLowerFirst(index a, index b, std::vector<std::mutex> &locks) {
@@ -130,6 +180,7 @@ private:
     double inverseGraphVolume; // 1/vol(V)
 
     std::vector<double> communityVolumes;
+    std::vector<count> communitySizes;
 
     std::vector<node> composedMapping;
 
@@ -162,6 +213,10 @@ private:
     ParallelLeidenCommunityScoreFunction communityScoreFunction_ = &modularityCommunityScore;
     ParallelLeidenCommunityScoreFunction currentCommunityThresholdFunction_ =
         &modularityThresholdScore;
+    ParallelLeidenRefineSetConditionFunction refineRSetConditionFunction_ =
+        &modularityRefineRSetCondition;
+    ParallelLeidenRefineSetConditionFunction refineTSetConditionFunction_ =
+        &modularityRefineTSetCondition;
     std::string scoringExtensionPath_;
 };
 

--- a/networkit/community.pyx
+++ b/networkit/community.pyx
@@ -710,6 +710,8 @@ cdef extern from "<networkit/community/ParallelLeidenView.hpp>":
 	cdef cppclass _ParallelLeidenView "NetworKit::ParallelLeidenView"(_CommunityDetectionAlgorithm):
 		_ParallelLeidenView(_Graph _G) except +
 		_ParallelLeidenView(_Graph _G, int iterations, bool_t randomize, double gamma) except +
+		void loadMoveScoringExtension(const string &sharedLibraryPath) except +
+		void unloadMoveScoringExtension() except +
 
 cdef class ParallelLeiden(CommunityDetector):
 	""" 
@@ -776,6 +778,28 @@ cdef class ParallelLeidenView(CommunityDetector):
 	def __cinit__(self, Graph G not None, int iterations = 3, bool_t randomize = True, double gamma = 1):
 		self._G = G
 		self._this = new _ParallelLeidenView(dereference(G._this),iterations,randomize,gamma)
+
+	def loadMoveScoringExtension(self, shared_library_path):
+		"""
+		loadMoveScoringExtension(shared_library_path)
+
+		Load a shared library that overrides the move-phase community scoring used by
+		ParallelLeidenView. The library must export
+		`networkitParallelLeidenCommunityScore` and may additionally export
+		`networkitParallelLeidenCurrentCommunityThreshold`.
+		"""
+		(<_ParallelLeidenView*>(self._this)).loadMoveScoringExtension(stdstring(shared_library_path))
+		return self
+
+	def unloadMoveScoringExtension(self):
+		"""
+		unloadMoveScoringExtension()
+
+		Unload a previously configured move-scoring extension and restore the
+		built-in modularity scorer.
+		"""
+		(<_ParallelLeidenView*>(self._this)).unloadMoveScoringExtension()
+		return self
 
 cdef extern from "<networkit/community/LouvainMapEquation.hpp>":
 	cdef cppclass _LouvainMapEquation "NetworKit::LouvainMapEquation"(_CommunityDetectionAlgorithm):

--- a/networkit/cpp/community/CMakeLists.txt
+++ b/networkit/cpp/community/CMakeLists.txt
@@ -52,4 +52,13 @@ set_target_properties(networkit_parallel_leiden_modularity_extension PROPERTIES
     CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
     CXX_STANDARD_REQUIRED YES)
 
+add_library(networkit_parallel_leiden_cpm_extension SHARED
+    ParallelLeidenCPMScoringExtension.cpp)
+target_include_directories(networkit_parallel_leiden_cpm_extension BEFORE PUBLIC
+    "${PROJECT_SOURCE_DIR}/include")
+set_target_properties(networkit_parallel_leiden_cpm_extension PROPERTIES
+    OUTPUT_NAME "networkit_parallel_leiden_cpm_extension"
+    CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED YES)
+
 add_subdirectory(test)

--- a/networkit/cpp/community/CMakeLists.txt
+++ b/networkit/cpp/community/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(networkit_parallel_leiden_modularity_extension SHARED
 target_include_directories(networkit_parallel_leiden_modularity_extension BEFORE PUBLIC
     "${PROJECT_SOURCE_DIR}/include")
 set_target_properties(networkit_parallel_leiden_modularity_extension PROPERTIES
-    OUTPUT_NAME "networkit_parallel_leiden_modularity_extension")
+    OUTPUT_NAME "networkit_parallel_leiden_modularity_extension"
+    CXX_STANDARD ${NETWORKIT_CXX_STANDARD}
+    CXX_STANDARD_REQUIRED YES)
 
 add_subdirectory(test)

--- a/networkit/cpp/community/CMakeLists.txt
+++ b/networkit/cpp/community/CMakeLists.txt
@@ -43,5 +43,11 @@ networkit_add_module(community
 networkit_module_link_modules(community
     auxiliary coarsening components flow graph matching scd structures)
 
-add_subdirectory(test)
+add_library(networkit_parallel_leiden_modularity_extension SHARED
+    ParallelLeidenModularityScoringExtension.cpp)
+target_include_directories(networkit_parallel_leiden_modularity_extension BEFORE PUBLIC
+    "${PROJECT_SOURCE_DIR}/include")
+set_target_properties(networkit_parallel_leiden_modularity_extension PROPERTIES
+    OUTPUT_NAME "networkit_parallel_leiden_modularity_extension")
 
+add_subdirectory(test)

--- a/networkit/cpp/community/ParallelLeidenCPMScoringExtension.cpp
+++ b/networkit/cpp/community/ParallelLeidenCPMScoringExtension.cpp
@@ -1,7 +1,7 @@
 /*
- * ParallelLeidenModularityScoringExtension.cpp
+ * ParallelLeidenCPMScoringExtension.cpp
  *
- *  Default modularity scorer exported through the ParallelLeidenView extension ABI.
+ *  Constant Potts Model scorer exported through the ParallelLeidenView extension ABI.
  */
 
 #include <networkit/community/ParallelLeidenScoringExtension.hpp>
@@ -12,9 +12,11 @@ extern "C" double networkitParallelLeidenCommunityScore(double cutWeight, double
                                                         NetworKit::count communitySize,
                                                         double gamma,
                                                         double inverseGraphVolume) {
-    (void)subsetSize;
-    (void)communitySize;
-    return cutWeight - gamma * degree * communityVolume * inverseGraphVolume;
+    (void)degree;
+    (void)communityVolume;
+    (void)inverseGraphVolume;
+    return cutWeight
+           - gamma * static_cast<double>(subsetSize) * static_cast<double>(communitySize);
 }
 
 extern "C" double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
@@ -23,9 +25,11 @@ extern "C" double networkitParallelLeidenCurrentCommunityThreshold(double cutWei
                                                                    NetworKit::count communitySize,
                                                                    double gamma,
                                                                    double inverseGraphVolume) {
-    (void)subsetSize;
-    (void)communitySize;
-    return cutWeight - gamma * (communityVolume - degree) * degree * inverseGraphVolume;
+    (void)degree;
+    (void)communityVolume;
+    (void)inverseGraphVolume;
+    return cutWeight - gamma * static_cast<double>(subsetSize)
+                           * static_cast<double>(communitySize - subsetSize);
 }
 
 extern "C" bool networkitParallelLeidenRefineRSetCondition(double cutWeight, double subsetVolume,
@@ -36,11 +40,12 @@ extern "C" bool networkitParallelLeidenRefineRSetCondition(double cutWeight, dou
                                                            NetworKit::count sourceSize,
                                                            double gamma,
                                                            double inverseGraphVolume) {
-    (void)subsetSize;
-    (void)targetSize;
+    (void)subsetVolume;
+    (void)targetVolume;
     (void)sourceVolume;
     (void)sourceSize;
-    return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
+    (void)inverseGraphVolume;
+    return cutWeight >= gamma * static_cast<double>(subsetSize) * static_cast<double>(targetSize);
 }
 
 extern "C" bool networkitParallelLeidenRefineTSetCondition(double cutWeight, double subsetVolume,
@@ -51,9 +56,10 @@ extern "C" bool networkitParallelLeidenRefineTSetCondition(double cutWeight, dou
                                                            NetworKit::count sourceSize,
                                                            double gamma,
                                                            double inverseGraphVolume) {
-    (void)subsetSize;
-    (void)targetSize;
+    (void)subsetVolume;
+    (void)targetVolume;
     (void)sourceVolume;
     (void)sourceSize;
-    return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
+    (void)inverseGraphVolume;
+    return cutWeight >= gamma * static_cast<double>(subsetSize) * static_cast<double>(targetSize);
 }

--- a/networkit/cpp/community/ParallelLeidenModularityScoringExtension.cpp
+++ b/networkit/cpp/community/ParallelLeidenModularityScoringExtension.cpp
@@ -7,14 +7,49 @@
 #include <networkit/community/ParallelLeidenScoringExtension.hpp>
 
 extern "C" double networkitParallelLeidenCommunityScore(double cutWeight, double degree,
-                                                        double communityVolume, double gamma,
+                                                        double communityVolume,
+                                                        NetworKit::count communitySize,
+                                                        double gamma,
                                                         double inverseGraphVolume) {
+    (void)communitySize;
     return cutWeight - gamma * degree * communityVolume * inverseGraphVolume;
 }
 
 extern "C" double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
                                                                    double communityVolume,
+                                                                   NetworKit::count communitySize,
                                                                    double gamma,
                                                                    double inverseGraphVolume) {
+    (void)communitySize;
     return cutWeight - gamma * (communityVolume - degree) * degree * inverseGraphVolume;
+}
+
+extern "C" bool networkitParallelLeidenRefineRSetCondition(double cutWeight, double subsetVolume,
+                                                           NetworKit::count subsetSize,
+                                                           double targetVolume,
+                                                           NetworKit::count targetSize,
+                                                           double sourceVolume,
+                                                           NetworKit::count sourceSize,
+                                                           double gamma,
+                                                           double inverseGraphVolume) {
+    (void)subsetSize;
+    (void)targetSize;
+    (void)sourceVolume;
+    (void)sourceSize;
+    return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
+}
+
+extern "C" bool networkitParallelLeidenRefineTSetCondition(double cutWeight, double subsetVolume,
+                                                           NetworKit::count subsetSize,
+                                                           double targetVolume,
+                                                           NetworKit::count targetSize,
+                                                           double sourceVolume,
+                                                           NetworKit::count sourceSize,
+                                                           double gamma,
+                                                           double inverseGraphVolume) {
+    (void)subsetSize;
+    (void)targetSize;
+    (void)sourceVolume;
+    (void)sourceSize;
+    return cutWeight >= gamma * subsetVolume * targetVolume * inverseGraphVolume;
 }

--- a/networkit/cpp/community/ParallelLeidenModularityScoringExtension.cpp
+++ b/networkit/cpp/community/ParallelLeidenModularityScoringExtension.cpp
@@ -1,0 +1,20 @@
+/*
+ * ParallelLeidenModularityScoringExtension.cpp
+ *
+ *  Default modularity scorer exported through the ParallelLeidenView extension ABI.
+ */
+
+#include <networkit/community/ParallelLeidenScoringExtension.hpp>
+
+extern "C" double networkitParallelLeidenCommunityScore(double cutWeight, double degree,
+                                                        double communityVolume, double gamma,
+                                                        double inverseGraphVolume) {
+    return cutWeight - gamma * degree * communityVolume * inverseGraphVolume;
+}
+
+extern "C" double networkitParallelLeidenCurrentCommunityThreshold(double cutWeight, double degree,
+                                                                   double communityVolume,
+                                                                   double gamma,
+                                                                   double inverseGraphVolume) {
+    return cutWeight - gamma * (communityVolume - degree) * degree * inverseGraphVolume;
+}

--- a/networkit/cpp/community/ParallelLeidenView.cpp
+++ b/networkit/cpp/community/ParallelLeidenView.cpp
@@ -492,7 +492,7 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                 if (pointers.empty())
                     continue;
 
-                double singletonScore = scoreCommunity(0.0, degree, 0.0, 0);
+                double singletonScore = scoreCommunity(0.0, degree, 0.0, nodeMass, 0);
 
                 // Determine move score for all neighbor communities
                 for (auto community : pointers) {
@@ -500,7 +500,7 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     if (community != currentCommunity) {
                         double delta;
                         delta = scoreCommunity(cutWeights[community], degree,
-                                               communityVolumes[community],
+                                               communityVolumes[community], nodeMass,
                                                communitySizes[community]);
                         if (delta > maxDelta) {
                             maxDelta = delta;
@@ -510,6 +510,7 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                 }
                 double modThreshold = scoreCurrentCommunityThreshold(
                     cutWeights[currentCommunity], degree, communityVolumes[currentCommunity],
+                    nodeMass,
                     communitySizes[currentCommunity]);
 
                 bool singletonMove = singletonScore > maxDelta;
@@ -763,7 +764,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                 continue;
             }
 
-            double singletonScore = scoreCommunity(0.0, degree, 0.0, 0);
+            double singletonScore = scoreCommunity(0.0, degree, 0.0, subsetSize, 0);
             double delta;
             index bestC = none;
             double bestDelta = std::numeric_limits<double>::lowest();
@@ -775,7 +776,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                     if (C == none) {
                         continue;
                     }
-                    delta = scoreCommunity(cutWeights[C], degree, refinedVolumes[C],
+                    delta = scoreCommunity(cutWeights[C], degree, refinedVolumes[C], subsetSize,
                                            refinedSizes[C]);
 
                     if (delta <= singletonScore) {

--- a/networkit/cpp/community/ParallelLeidenView.cpp
+++ b/networkit/cpp/community/ParallelLeidenView.cpp
@@ -13,6 +13,16 @@
 
 namespace NetworKit {
 
+count ParallelLeidenView::nodeSize(const Graph &graph, node u) {
+    tlx::unused(graph);
+    tlx::unused(u);
+    return 1;
+}
+
+count ParallelLeidenView::nodeSize(const CoarsenedGraphView &graph, node u) {
+    return graph.getOriginalNodes(u).size();
+}
+
 ParallelLeidenView::ParallelLeidenView(const Graph &graph, int iterations, bool randomize,
                                        double gamma)
     : CommunityDetectionAlgorithm(graph), gamma(gamma), numberOfIterations(iterations),
@@ -71,6 +81,7 @@ ParallelLeidenView::~ParallelLeidenView() {
     composedMapping.clear();
     composedMapping.shrink_to_fit();
     communityVolumes.clear();
+    communitySizes.clear();
 }
 
 void ParallelLeidenView::loadMoveScoringExtension(const std::string &sharedLibraryPath) {
@@ -108,6 +119,21 @@ void ParallelLeidenView::loadMoveScoringExtension(const std::string &sharedLibra
     communityScoreFunction_ = communityScore;
     currentCommunityThresholdFunction_ = thresholdScore != nullptr ? thresholdScore
                                                                    : &modularityThresholdScore;
+    dlerror();
+    auto *refineRSet = reinterpret_cast<ParallelLeidenRefineSetConditionFunction>(
+        dlsym(handle, "networkitParallelLeidenRefineRSetCondition"));
+    const char *refineRSetError = dlerror();
+    refineRSetConditionFunction_ =
+        refineRSetError == nullptr && refineRSet != nullptr ? refineRSet
+                                                            : &modularityRefineRSetCondition;
+
+    dlerror();
+    auto *refineTSet = reinterpret_cast<ParallelLeidenRefineSetConditionFunction>(
+        dlsym(handle, "networkitParallelLeidenRefineTSetCondition"));
+    const char *refineTSetError = dlerror();
+    refineTSetConditionFunction_ =
+        refineTSetError == nullptr && refineTSet != nullptr ? refineTSet
+                                                            : &modularityRefineTSetCondition;
     scoringExtensionPath_ = sharedLibraryPath;
 #endif
 }
@@ -115,6 +141,8 @@ void ParallelLeidenView::loadMoveScoringExtension(const std::string &sharedLibra
 void ParallelLeidenView::unloadMoveScoringExtension() {
     communityScoreFunction_ = &modularityCommunityScore;
     currentCommunityThresholdFunction_ = &modularityThresholdScore;
+    refineRSetConditionFunction_ = &modularityRefineRSetCondition;
+    refineTSetConditionFunction_ = &modularityRefineTSetCondition;
     scoringExtensionPath_.clear();
 #ifndef _WIN32
     if (scoringExtensionHandle_ != nullptr) {
@@ -309,15 +337,20 @@ void ParallelLeidenView::calculateVolumes(const GraphType &graph) {
 
     // thread safe reduction. Avoid atomic calculation of total graph volume for unweighted graphs.
     communityVolumes.clear();
+    communitySizes.clear();
     communityVolumes.resize(result.upperBound() + VECTOR_OVERSIZE);
+    communitySizes.resize(result.upperBound() + VECTOR_OVERSIZE);
     inverseGraphVolume = 0.0; // Reset to 0 before accumulation
 
     if (graph.isWeighted()) {
         std::vector<double> threadVolumes(omp_get_max_threads());
         graph.parallelForNodes([&](node a) {
             edgeweight ew = graph.weightedDegree(a, true);
+            count size = nodeSize(graph, a);
 #pragma omp atomic
             communityVolumes[result[a]] += ew;
+#pragma omp atomic
+            communitySizes[result[a]] += size;
             threadVolumes[omp_get_thread_num()] += ew;
         });
         for (const auto vol : threadVolumes) {
@@ -327,8 +360,11 @@ void ParallelLeidenView::calculateVolumes(const GraphType &graph) {
     } else {
         inverseGraphVolume = 1.0 / (2 * graph.numberOfEdges());
         graph.parallelForNodes([&](node a) {
+            count size = nodeSize(graph, a);
 #pragma omp atomic
             communityVolumes[result[a]] += graph.weightedDegree(a, true);
+#pragma omp atomic
+            communitySizes[result[a]] += size;
         });
     }
     TRACE("Calculating Volumes took " + timer.elapsedTag());
@@ -433,6 +469,7 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                 double maxDelta = std::numeric_limits<double>::lowest();
                 index bestCommunity = none;
                 double degree = 0;
+                count nodeMass = nodeSize(graph, u);
                 for (auto z : pointers) {
                     // Reset the clearlist : Set all cutweights to 0 and clear the pointer vector
                     cutWeights[z] = 0;
@@ -455,13 +492,16 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                 if (pointers.empty())
                     continue;
 
-                // Determine Modularity delta for all neighbor communities
+                double singletonScore = scoreCommunity(0.0, degree, 0.0, 0);
+
+                // Determine move score for all neighbor communities
                 for (auto community : pointers) {
                     // "Moving" a node to its current community is pointless
                     if (community != currentCommunity) {
                         double delta;
                         delta = scoreCommunity(cutWeights[community], degree,
-                                               communityVolumes[community]);
+                                               communityVolumes[community],
+                                               communitySizes[community]);
                         if (delta > maxDelta) {
                             maxDelta = delta;
                             bestCommunity = community;
@@ -469,19 +509,16 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     }
                 }
                 double modThreshold = scoreCurrentCommunityThreshold(
-                    cutWeights[currentCommunity], degree, communityVolumes[currentCommunity]);
+                    cutWeights[currentCommunity], degree, communityVolumes[currentCommunity],
+                    communitySizes[currentCommunity]);
 
-                if (0 > modThreshold || maxDelta > modThreshold) {
+                bool singletonMove = singletonScore > maxDelta;
+                double selectedScore = singletonMove ? singletonScore : maxDelta;
+                if (selectedScore > modThreshold) {
                     bool acceptedMove = false;
-                    bool singletonMove = (0 > maxDelta);
                     double gainMargin = 0.0;
-                    if (singletonMove) {
-                        gainMargin = -modThreshold;
-                        acceptedMove = (0 > modThreshold);
-                    } else {
-                        gainMargin = maxDelta - modThreshold;
-                        acceptedMove = (maxDelta > modThreshold);
-                    }
+                    gainMargin = selectedScore - modThreshold;
+                    acceptedMove = true;
                     if (acceptedMove && gainMargin <= moveGainMarginEpsilon) {
                         marginalMovesRejected[omp_get_thread_num()]++;
                         acceptedMove = false;
@@ -505,6 +542,7 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                                 }
                                 // all other threads are yielding, so resize is fine
                                 communityVolumes.resize(vectorSize);
+                                communitySizes.resize(vectorSize);
                                 expected = true;
                                 resize.compare_exchange_strong(expected, false);
                             } else {
@@ -525,6 +563,10 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     communityVolumes[bestCommunity] += degree;
 #pragma omp atomic
                     communityVolumes[currentCommunity] -= degree;
+#pragma omp atomic
+                    communitySizes[bestCommunity] += nodeMass;
+#pragma omp atomic
+                    communitySizes[currentCommunity] -= nodeMass;
                     changed = true;
                     bool expected = true;
                     inQueue[u].compare_exchange_strong(expected, false);
@@ -633,6 +675,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
     std::vector<uint_fast8_t> singleton(refined.upperBound(), true);
     std::vector<double> cutCtoSminusC(refined.upperBound());
     std::vector<double> refinedVolumes(refined.upperBound()); // Community Volumes P_refined
+    std::vector<count> refinedSizes(refined.upperBound());
     std::vector<std::mutex> locks(refined.upperBound());
     std::vector<node> nodes(graph.upperNodeIdBound(), none);
 
@@ -646,6 +689,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
         for (omp_index u = 0; u < static_cast<omp_index>(graph.upperNodeIdBound()); u++) {
             if (graph.hasNode(u)) {
                 nodes[u] = u;
+                refinedSizes[u] = nodeSize(graph, u);
                 graph.forNeighborsOf(u, [&](node neighbor, edgeweight ew) {
                     if (u != neighbor) {
                         if (result[neighbor] == result[u]) {
@@ -689,6 +733,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
             // Nodes whose community ID equals their Node ID. These may be singletons that can
             // affect the cut which we need to update later
             double degree = 0;
+            count subsetSize = nodeSize(graph, u);
 
             graph.forNeighborsOf(u, [&](node neighbor, edgeweight ew) { // Calculate degree and cut
                 degree += ew;
@@ -708,8 +753,9 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                     degree += ew;
                 }
             });
-            if (cutCtoSminusC[u] < this->gamma * degree * (communityVolumes[S] - degree)
-                                       * inverseGraphVolume) { // R-Set Condition
+            if (!refineRSetCondition(cutCtoSminusC[u], degree, subsetSize,
+                                     communityVolumes[S] - degree, communitySizes[S] - subsetSize,
+                                     communityVolumes[S], communitySizes[S])) {
                 continue;
             }
 
@@ -717,6 +763,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                 continue;
             }
 
+            double singletonScore = scoreCommunity(0.0, degree, 0.0, 0);
             double delta;
             index bestC = none;
             double bestDelta = std::numeric_limits<double>::lowest();
@@ -728,16 +775,20 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                     if (C == none) {
                         continue;
                     }
-                    delta = scoreCommunity(cutWeights[C], degree, refinedVolumes[C]);
+                    delta = scoreCommunity(cutWeights[C], degree, refinedVolumes[C],
+                                           refinedSizes[C]);
 
-                    if (delta < 0) { // modThreshold is 0, since cutw(v,C-) = 0 and volw(C-) = 0
+                    if (delta <= singletonScore) {
                         continue;
                     }
 
                     auto volC = refinedVolumes[C];
+                    auto sizeC = refinedSizes[C];
                     if (delta > bestDelta
-                        && cutCtoSminusC[C] >= this->gamma * volC * (communityVolumes[S] - volC)
-                                                   * inverseGraphVolume) { // T-Set Condition
+                        && refineTSetCondition(cutCtoSminusC[C], volC, sizeC,
+                                               communityVolumes[S] - volC,
+                                               communitySizes[S] - sizeC, communityVolumes[S],
+                                               communitySizes[S])) {
                         bestDelta = delta;
                         bestC = C;
                         idx = j;
@@ -807,6 +858,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                 singleton[bestC] = false;
                 refined[u] = bestC;
                 refinedVolumes[bestC] += degree;
+                refinedSizes[bestC] += subsetSize;
                 updateCut();
                 cutCtoSminusC[bestC] += cutCtoSminusC[u] - 2 * cutWeights[bestC];
             }

--- a/networkit/cpp/community/ParallelLeidenView.cpp
+++ b/networkit/cpp/community/ParallelLeidenView.cpp
@@ -6,6 +6,10 @@
 
 #include <networkit/community/ParallelLeidenView.hpp>
 #include <cstdlib>
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+#include <stdexcept>
 
 namespace NetworKit {
 
@@ -56,13 +60,70 @@ ParallelLeidenView::ParallelLeidenView(const Graph &graph, int iterations, bool 
             // Keep default if parsing fails.
         }
     }
+    if (const char *scoringLibEnv = std::getenv("NETWORKIT_LEIDEN_MOVE_SCORING_LIB")) {
+        loadMoveScoringExtension(scoringLibEnv);
+    }
 }
 
 ParallelLeidenView::~ParallelLeidenView() {
+    unloadMoveScoringExtension();
     currentCoarsenedView.reset();
     composedMapping.clear();
     composedMapping.shrink_to_fit();
     communityVolumes.clear();
+}
+
+void ParallelLeidenView::loadMoveScoringExtension(const std::string &sharedLibraryPath) {
+#ifdef _WIN32
+    throw std::runtime_error(
+        "ParallelLeidenView shared-library scoring extensions are not supported on Windows");
+#else
+    void *handle = dlopen(sharedLibraryPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+        throw std::runtime_error("Failed to load ParallelLeidenView scoring extension '" +
+                                 sharedLibraryPath + "': " + dlerror());
+    }
+
+    dlerror();
+    auto *communityScore = reinterpret_cast<ParallelLeidenCommunityScoreFunction>(
+        dlsym(handle, "networkitParallelLeidenCommunityScore"));
+    const char *communityScoreError = dlerror();
+    if (communityScoreError != nullptr || communityScore == nullptr) {
+        dlclose(handle);
+        throw std::runtime_error(
+            "ParallelLeidenView scoring extension '" + sharedLibraryPath
+            + "' does not export required symbol networkitParallelLeidenCommunityScore");
+    }
+
+    dlerror();
+    auto *thresholdScore = reinterpret_cast<ParallelLeidenCommunityScoreFunction>(
+        dlsym(handle, "networkitParallelLeidenCurrentCommunityThreshold"));
+    const char *thresholdScoreError = dlerror();
+    if (thresholdScoreError != nullptr) {
+        thresholdScore = &modularityThresholdScore;
+    }
+
+    unloadMoveScoringExtension();
+    scoringExtensionHandle_ = handle;
+    communityScoreFunction_ = communityScore;
+    currentCommunityThresholdFunction_ = thresholdScore != nullptr ? thresholdScore
+                                                                   : &modularityThresholdScore;
+    scoringExtensionPath_ = sharedLibraryPath;
+#endif
+}
+
+void ParallelLeidenView::unloadMoveScoringExtension() {
+    communityScoreFunction_ = &modularityCommunityScore;
+    currentCommunityThresholdFunction_ = &modularityThresholdScore;
+    scoringExtensionPath_.clear();
+#ifndef _WIN32
+    if (scoringExtensionHandle_ != nullptr) {
+        dlclose(scoringExtensionHandle_);
+        scoringExtensionHandle_ = nullptr;
+    }
+#else
+    scoringExtensionHandle_ = nullptr;
+#endif
 }
 
 void ParallelLeidenView::run() {
@@ -399,16 +460,16 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     // "Moving" a node to its current community is pointless
                     if (community != currentCommunity) {
                         double delta;
-                        delta = modularityDelta(cutWeights[community], degree,
-                                                communityVolumes[community]);
+                        delta = scoreCommunity(cutWeights[community], degree,
+                                               communityVolumes[community]);
                         if (delta > maxDelta) {
                             maxDelta = delta;
                             bestCommunity = community;
                         }
                     }
                 }
-                double modThreshold = modularityThreshold(
-                    cutWeights[currentCommunity], communityVolumes[currentCommunity], degree);
+                double modThreshold = scoreCurrentCommunityThreshold(
+                    cutWeights[currentCommunity], degree, communityVolumes[currentCommunity]);
 
                 if (0 > modThreshold || maxDelta > modThreshold) {
                     bool acceptedMove = false;
@@ -667,7 +728,7 @@ Partition ParallelLeidenView::parallelRefine(const GraphType &graph) {
                     if (C == none) {
                         continue;
                     }
-                    delta = modularityDelta(cutWeights[C], degree, refinedVolumes[C]);
+                    delta = scoreCommunity(cutWeights[C], degree, refinedVolumes[C]);
 
                     if (delta < 0) { // modThreshold is 0, since cutw(v,C-) = 0 and volw(C-) = 0
                         continue;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
   "scipy",
   "numpy",
-  "pyarrow"
+  "pyarrow>=23.0.1,<24.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "icebug"
 version = "12.5"
 description = "High performance graph analytics backed by read-only memory"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "License.txt"}
 keywords =["graph algorithm", "network analysis", "social network", "apache arrow", "columnar"]
 authors = [


### PR DESCRIPTION
Implement an API to allow users to bring their own scoring libs

Sample usage:

```
uv run python examples/parallel_leiden_scoring_extension_demo.py --plugin \
build/networkit/cpp/community/libnetworkit_parallel_leiden_modularity_extension.dylib
```