### PR TITLE
Improve IcebugMemGraph loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Icebug also offers two ways to load a graph from CSR format enabling zero-copy l
     >>> nodes = pa.table({"id": pa.array([0, 1, 2], type=pa.int64())})
     >>> rels  = pa.table({"source": pa.array([0, 1, 2], type=pa.int64()),
     ...                   "target": pa.array([1, 2, 0], type=pa.int64())})
-    >>> mem = IcebugMemGraph.from_arrow_tables(nodes, nodes, rels, directed=True)
+    >>> mem = IcebugMemGraph.from_arrow_tables(nodes, rels)
     >>> g = nk.graph.Graph.fromIcebugMemGraph(mem)
 
     # using fromCSR directly

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -1,6 +1,8 @@
 # distutils: language=c++
 
 from cython.operator import dereference, preincrement
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from libcpp.algorithm cimport swap
 
 import numpy as np
@@ -288,11 +290,12 @@ cdef class Graph:
 		Raises
 		------
 		TypeError
-			If *graph* is missing a required attribute (``src``, ``indices``,
-			or ``indptr``), or if ``indices`` / ``indptr`` are not
+			If *graph* is missing a required attribute (``src``, ``dest``,
+			``indices``, or ``indptr``), or if these attributes are not
 			:class:`pyarrow.Table` instances.
 		ValueError
-			If ``graph.indices`` or ``graph.indptr`` contain no columns.
+			If ``graph.src`` and ``graph.dest`` differ, or if
+			``graph.indices`` or ``graph.indptr`` contain no columns.
 		"""
 		for attr in ('src', 'indices', 'indptr'):
 			if not hasattr(graph, attr):
@@ -314,6 +317,22 @@ cdef class Graph:
 			raise TypeError(
 				f"graph.indptr must be a pyarrow.Table, got {type(graph.indptr).__name__}"
 			)
+
+		if not hasattr(graph, 'dest'):
+			raise TypeError(
+				"graph must be an IcebugMemGraph; missing required attribute 'dest'"
+			)
+
+		if not isinstance(graph.dest, pa.Table):
+			raise TypeError(
+				f"graph.dest must be a pyarrow.Table, got {type(graph.dest).__name__}"
+			)
+
+		if not graph.src.equals(graph.dest):
+			raise ValueError(
+				"Graph.fromIcebugMemGraph only supports homogeneous graphs where "
+				"graph.src equals graph.dest"
+			)
 		
 		if graph.indices.num_columns == 0:
 			raise ValueError("graph.indices must have at least one column")
@@ -322,14 +341,31 @@ cdef class Graph:
 
 		n = graph.src.num_rows
 
+		def combine_chunks(chunked):
+			chunks = chunked.chunks
+			offsets = np.cumsum([0] + [len(c) for c in chunks])
+			out = np.empty(offsets[-1], dtype=np.uint64)
+
+			def copy_chunk(i):
+				out[offsets[i]:offsets[i + 1]] = chunks[i].to_numpy(zero_copy_only=False)
+
+			with ThreadPoolExecutor() as ex:
+				deque(ex.map(copy_chunk, range(len(chunks))), maxlen=0)
+
+			return pa.array(out, type=pa.uint64())
+
+		def table_column_as_uint64_array(table, column):
+			chunked = table.column(column).cast(pa.uint64())
+			return combine_chunks(chunked)
+
 		# Prefer the 'target' column; fall back to the first column
 		if 'target' in graph.indices.column_names:
-			out_indices = graph.indices.column('target').cast(pa.uint64())
+			out_indices = table_column_as_uint64_array(graph.indices, 'target')
 		else:
-			out_indices = graph.indices.column(0).cast(pa.uint64())
+			out_indices = table_column_as_uint64_array(graph.indices, 0)
 
 		# Always use the first column of indptr
-		out_indptr = graph.indptr.column(0).cast(pa.uint64())
+		out_indptr = table_column_as_uint64_array(graph.indptr, 0)
 
 		return cls.fromCSR(n, directed, out_indices, out_indptr)
 

--- a/networkit/test/test_icebug_mem_graph.py
+++ b/networkit/test/test_icebug_mem_graph.py
@@ -111,6 +111,19 @@ class TestFromIcebugMemGraph(unittest.TestCase):
         with self.assertRaises(TypeError) as ctx:
             nk.Graph.fromIcebugMemGraph(FakeGraph())
         self.assertIn("indptr", str(ctx.exception))
+
+    def test_missing_dest_attribute_raises_type_error(self):
+        """An object missing 'dest' raises TypeError."""
+        nodes = pa.table({"id": pa.array([0, 1], type=pa.int64())})
+
+        class FakeGraph:
+            src = nodes
+            indices = pa.table({"target": pa.array([1], type=pa.uint64())})
+            indptr = pa.table({"ptr": pa.array([0, 1, 1], type=pa.uint64())})
+
+        with self.assertRaises(TypeError) as ctx:
+            nk.Graph.fromIcebugMemGraph(FakeGraph())
+        self.assertIn("dest", str(ctx.exception))
     
     def test_src_not_a_table_raises_type_error(self):
         """graph.src that is not a pa.Table raises TypeError."""
@@ -149,12 +162,42 @@ class TestFromIcebugMemGraph(unittest.TestCase):
             nk.Graph.fromIcebugMemGraph(FakeGraph())
         self.assertIn("indptr", str(ctx.exception))
 
+    def test_dest_not_a_table_raises_type_error(self):
+        """graph.dest that is not a pa.Table raises TypeError."""
+        nodes = pa.table({"id": pa.array([0, 1], type=pa.int64())})
+
+        class FakeGraph:
+            src = nodes
+            dest = [0, 1]  # wrong type
+            indices = pa.table({"target": pa.array([1], type=pa.uint64())})
+            indptr = pa.table({"ptr": pa.array([0, 1, 1], type=pa.uint64())})
+
+        with self.assertRaises(TypeError) as ctx:
+            nk.Graph.fromIcebugMemGraph(FakeGraph())
+        self.assertIn("dest", str(ctx.exception))
+
+    def test_heterogeneous_src_dest_raises_value_error(self):
+        """Separate source and destination node tables are rejected."""
+        src_nodes = pa.table({"id": pa.array([0, 1], type=pa.int64())})
+        dest_nodes = pa.table({"id": pa.array([10, 11], type=pa.int64())})
+        mem = IcebugMemGraph(
+            src=src_nodes,
+            dest=dest_nodes,
+            indices=pa.table({"target": pa.array([0, 1], type=pa.uint64())}),
+            indptr=pa.table({"ptr": pa.array([0, 1, 2], type=pa.uint64())}),
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            nk.Graph.fromIcebugMemGraph(mem)
+        self.assertIn("homogeneous", str(ctx.exception))
+
     def test_indices_empty_columns_raises_value_error(self):
         """graph.indices with no columns raises ValueError."""
         nodes = pa.table({"id": pa.array([0, 1, 2], type=pa.int64())})
 
         class FakeGraph:
             src = nodes
+            dest = nodes
             indices = pa.table({})   # no columns
             indptr = pa.table({"ptr": pa.array([0, 1, 2, 3], type=pa.uint64())})
 
@@ -168,6 +211,7 @@ class TestFromIcebugMemGraph(unittest.TestCase):
 
         class FakeGraph:
             src = nodes
+            dest = nodes
             indices = pa.table({"target": pa.array([1, 2, 0], type=pa.uint64())})
             indptr = pa.table({})  # no columns
 
@@ -195,6 +239,30 @@ class TestFromIcebugMemGraph(unittest.TestCase):
         G = nk.Graph.fromIcebugMemGraph(mem, directed=True)
         self.assertEqual(G.numberOfNodes(), 3)
         self.assertEqual(G.numberOfEdges(), 3)
+
+    def test_chunked_columns_are_combined(self):
+        """Chunked table columns are accepted."""
+        indices = pa.table({
+            "target": pa.chunked_array([
+                pa.array([1, 2], type=pa.uint64()),
+                pa.array([0], type=pa.uint64()),
+            ])
+        })
+        indptr = pa.table({
+            "ptr": pa.chunked_array([
+                pa.array([0, 1], type=pa.uint64()),
+                pa.array([2, 3], type=pa.uint64()),
+            ])
+        })
+        nodes = pa.table({"id": pa.array([0, 1, 2], type=pa.int64())})
+        mem = IcebugMemGraph(src=nodes, dest=nodes, indices=indices, indptr=indptr)
+
+        G = nk.Graph.fromIcebugMemGraph(mem, directed=True)
+        self.assertEqual(G.numberOfNodes(), 3)
+        self.assertEqual(G.numberOfEdges(), 3)
+        self.assertTrue(G.hasEdge(0, 1))
+        self.assertTrue(G.hasEdge(1, 2))
+        self.assertTrue(G.hasEdge(2, 0))
 
 
     # ------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,13 @@ classifiers = [
 ]
 
 dependencies = [
+  "cython>=3.1.0",
+  "duckdb",
   "scipy",
   "numpy",
   "pyarrow>=23.0.1,<24.0",
-  "icebug-format>=1.0.0"
+  "icebug-format>=1.0.0",
+  "pytest"
 ]
 
 [project.optional-dependencies]
@@ -59,7 +62,7 @@ addopts = ["--ignore=extlibs"]
 
 [build-system]
 requires = [
-  "cython<3.1.0",
+  "cython>=3.1.0",
   "numpy",
   "setuptools",
   "wheel"


### PR DESCRIPTION
## Summary

- Heterogeneous src/dest is now rejected.
- Chunked Arrow columns now have an explicit combine path.
- Missing duckdb/pytest/cython dependency issue is addressed in pyproject.toml.
- Update README for directed IcebugMemGraph construction.

## Validation

- PYTHONPATH=../icebug-format uv run --no-sync python -m pytest networkit/test/test_icebug_mem_graph.py -q
