### PR TITLE
Fix Leiden move requeue state

### DIFF
--- a/networkit/cpp/community/ParallelLeiden.cpp
+++ b/networkit/cpp/community/ParallelLeiden.cpp
@@ -1,4 +1,5 @@
 #include <networkit/community/ParallelLeiden.hpp>
+#include <cstdint>
 
 namespace NetworKit {
 ParallelLeiden::ParallelLeiden(const Graph &graph, int iterations, bool randomize, double gamma)
@@ -122,16 +123,19 @@ void ParallelLeiden::flattenPartition() {
 }
 
 void ParallelLeiden::parallelMove(const Graph &graph) {
+    enum : uint8_t { Idle, Queued, Processing, Reprocess };
+
     DEBUG("Local Moving : ", graph.numberOfNodes(), " Nodes ");
     std::vector<count> moved(omp_get_max_threads(), 0);
     std::vector<count> totalNodesPerThread(omp_get_max_threads(), 0);
     std::atomic_int singleton(0);
     //^^^ Debug stuff
 
-    // Only insert nodes to the queue when they're not already in it.
-    std::vector<std::atomic_bool> inQueue(graph.upperNodeIdBound());
-    for (auto &val : inQueue) {
-        val.store(false);
+    // Track whether nodes are idle, queued, currently processed, or need another pass after the
+    // current processing attempt finishes.
+    std::vector<std::atomic<uint8_t>> nodeState(graph.upperNodeIdBound());
+    for (auto &val : nodeState) {
+        val.store(Idle);
     }
     std::queue<std::vector<node>> queue;
     std::mutex qlock;                      // queue lock
@@ -167,13 +171,64 @@ void ParallelLeiden::parallelMove(const Graph &graph) {
         // cutWeight[Community] returns cut of Node to Community
         std::vector<double> cutWeights(communityVolumes.capacity());
         std::vector<index> pointers;
+
+        auto pushNewNode = [&](node queuedNode) {
+            newNodes.push_back(queuedNode);
+            // push new nodes to the queue in WORKING_SIZE steps
+            if (newNodes.size() == WORKING_SIZE) {
+                qlock.lock();
+                queue.emplace(std::move(newNodes));
+                qlock.unlock();
+                // Notify threads that new is available
+                workAvailable.notify_all();
+                newNodes.clear();
+                newNodes.reserve(WORKING_SIZE);
+            }
+        };
+
+        auto scheduleNode = [&](node queuedNode) {
+            uint8_t state = nodeState[queuedNode].load();
+            while (true) {
+                if (state == Idle) {
+                    uint8_t expected = Idle;
+                    if (nodeState[queuedNode].compare_exchange_strong(expected, Queued)) {
+                        pushNewNode(queuedNode);
+                        return;
+                    }
+                    state = expected;
+                } else if (state == Processing) {
+                    uint8_t expected = Processing;
+                    if (nodeState[queuedNode].compare_exchange_strong(expected, Reprocess)) {
+                        return;
+                    }
+                    state = expected;
+                } else {
+                    return;
+                }
+            }
+        };
+
+        auto finishProcessingNode = [&](node processedNode) {
+            uint8_t expected = Processing;
+            if (nodeState[processedNode].compare_exchange_strong(expected, Idle)) {
+                return;
+            }
+            assert(expected == Reprocess);
+            expected = Reprocess;
+            const bool markedQueued =
+                nodeState[processedNode].compare_exchange_strong(expected, Queued);
+            assert(markedQueued);
+            tlx::unused(markedQueued);
+            pushNewNode(processedNode);
+        };
+
         int start = tshare * order[omp_get_thread_num()];
         int end = (1 + order[omp_get_thread_num()]) * tshare;
 
         for (int i = start; i < end; i++) {
             if (graph.hasNode(i)) {
                 currentNodes.push_back(i);
-                inQueue[i].store(true);
+                nodeState[i].store(Queued);
             }
         }
         if (random)
@@ -192,7 +247,11 @@ void ParallelLeiden::parallelMove(const Graph &graph) {
                     waitingForResize--;
                 }
                 cutWeights.resize(vectorSize);
-                assert(inQueue[u]);
+                uint8_t expectedState = Queued;
+                const bool startedProcessing =
+                    nodeState[u].compare_exchange_strong(expectedState, Processing);
+                assert(startedProcessing);
+                tlx::unused(startedProcessing);
                 index currentCommunity = result[u];
                 double maxDelta = std::numeric_limits<double>::lowest();
                 index bestCommunity = none;
@@ -216,8 +275,10 @@ void ParallelLeiden::parallelMove(const Graph &graph) {
                     degree += ew; // keep track of the nodes degree. Loops count twice
                 });
 
-                if (pointers.empty())
+                if (pointers.empty()) {
+                    finishProcessingNode(u);
                     continue;
+                }
 
                 // Determine Modularity delta for all neighbor communities
                 for (auto community : pointers) {
@@ -271,31 +332,15 @@ void ParallelLeiden::parallelMove(const Graph &graph) {
 #pragma omp atomic
                     communityVolumes[currentCommunity] -= degree;
                     changed = true;
-                    bool expected = true;
-                    inQueue[u].compare_exchange_strong(expected, false);
-                    assert(expected);
                     graph.forNeighborsOf(u, [&](node neighbor) {
                         // Only add the node to the queue if it's not already
                         // in it, and it's not the Node we're currently moving
                         if (result[neighbor] != bestCommunity && neighbor != u) {
-                            expected = false;
-                            if (inQueue[neighbor].compare_exchange_strong(expected, true)) {
-                                newNodes.push_back(neighbor);
-                                // push new nodes to the queue in WORKING_SIZE steps
-                                if (newNodes.size() == WORKING_SIZE) {
-                                    qlock.lock();
-                                    queue.emplace(std::move(newNodes));
-                                    qlock.unlock();
-                                    // Notify threads that new is available
-                                    workAvailable.notify_all();
-                                    newNodes.clear();
-                                    newNodes.reserve(WORKING_SIZE);
-                                }
-                                assert(!expected);
-                            }
+                            scheduleNode(neighbor);
                         }
                     });
                 }
+                finishProcessingNode(u);
             }
 
             // queue check/wait

--- a/networkit/cpp/community/ParallelLeidenView.cpp
+++ b/networkit/cpp/community/ParallelLeidenView.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <networkit/community/ParallelLeidenView.hpp>
+#include <cstdint>
 #include <cstdlib>
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -355,6 +356,8 @@ void ParallelLeidenView::flattenPartition() {
 
 template <typename GraphType>
 ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &graph) {
+    enum : uint8_t { Idle, Queued, Processing, Reprocess };
+
     DEBUG("Local Moving : ", graph.numberOfNodes(), " Nodes ");
     std::vector<count> moved(omp_get_max_threads(), 0);
     std::vector<count> movedToSingleton(omp_get_max_threads(), 0);
@@ -365,10 +368,11 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
     std::vector<count> totalNodesPerThread(omp_get_max_threads(), 0);
     std::atomic_int singleton(0);
 
-    // Only insert nodes to the queue when they're not already in it.
-    std::vector<std::atomic_bool> inQueue(graph.upperNodeIdBound());
-    for (auto &val : inQueue) {
-        val.store(false);
+    // Track whether nodes are idle, queued, currently processed, or need another pass after the
+    // current processing attempt finishes.
+    std::vector<std::atomic<uint8_t>> nodeState(graph.upperNodeIdBound());
+    for (auto &val : nodeState) {
+        val.store(Idle);
     }
     std::queue<std::vector<node>> queue;
     std::mutex qlock;                      // queue lock
@@ -405,13 +409,64 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
         // Sparse cutWeight[Community] storage avoids one dense community vector per thread.
         std::unordered_map<index, double> cutWeights;
         std::vector<index> pointers;
+
+        auto pushNewNode = [&](node queuedNode) {
+            newNodes.push_back(queuedNode);
+            // push new nodes to the queue in WORKING_SIZE steps
+            if (newNodes.size() == WORKING_SIZE) {
+                qlock.lock();
+                queue.emplace(std::move(newNodes));
+                qlock.unlock();
+                // Notify threads that new is available
+                workAvailable.notify_all();
+                newNodes.clear();
+                newNodes.reserve(WORKING_SIZE);
+            }
+        };
+
+        auto scheduleNode = [&](node queuedNode) {
+            uint8_t state = nodeState[queuedNode].load();
+            while (true) {
+                if (state == Idle) {
+                    uint8_t expected = Idle;
+                    if (nodeState[queuedNode].compare_exchange_strong(expected, Queued)) {
+                        pushNewNode(queuedNode);
+                        return;
+                    }
+                    state = expected;
+                } else if (state == Processing) {
+                    uint8_t expected = Processing;
+                    if (nodeState[queuedNode].compare_exchange_strong(expected, Reprocess)) {
+                        return;
+                    }
+                    state = expected;
+                } else {
+                    return;
+                }
+            }
+        };
+
+        auto finishProcessingNode = [&](node processedNode) {
+            uint8_t expected = Processing;
+            if (nodeState[processedNode].compare_exchange_strong(expected, Idle)) {
+                return;
+            }
+            assert(expected == Reprocess);
+            expected = Reprocess;
+            const bool markedQueued =
+                nodeState[processedNode].compare_exchange_strong(expected, Queued);
+            assert(markedQueued);
+            tlx::unused(markedQueued);
+            pushNewNode(processedNode);
+        };
+
         int start = tshare * order[omp_get_thread_num()];
         int end = (1 + order[omp_get_thread_num()]) * tshare;
 
         for (int i = start; i < end; i++) {
             if (graph.hasNode(i)) {
                 currentNodes.push_back(i);
-                inQueue[i].store(true);
+                nodeState[i].store(Queued);
             }
         }
         if (random)
@@ -428,7 +483,11 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     }
                     waitingForResize--;
                 }
-                assert(inQueue[u]);
+                uint8_t expectedState = Queued;
+                const bool startedProcessing =
+                    nodeState[u].compare_exchange_strong(expectedState, Processing);
+                assert(startedProcessing);
+                tlx::unused(startedProcessing);
                 index currentCommunity = result[u];
                 double maxDelta = std::numeric_limits<double>::lowest();
                 index bestCommunity = none;
@@ -453,8 +512,10 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     degree += ew; // keep track of the nodes degree. Loops count twice
                 });
 
-                if (pointers.empty())
+                if (pointers.empty()) {
+                    finishProcessingNode(u);
                     continue;
+                }
 
                 double singletonScore = scoreCommunity(0.0, degree, 0.0, nodeMass, 0);
 
@@ -494,73 +555,57 @@ ParallelLeidenView::MoveStats ParallelLeidenView::parallelMove(const GraphType &
                     }
 
                     if (acceptedMove) {
-                    const int tid = omp_get_thread_num();
-                    moved[tid]++;
-                    if (singletonMove) { // move node to empty community
-                        singleton++;
-                        movedToSingleton[tid]++;
-                        bestCommunity = upperBound++;
-                        if (bestCommunity >= communityVolumes.size()) {
-                            // Wait until all other threads yielded, then increase vector size
-                            bool expected = false;
-                            if (resize.compare_exchange_strong(expected, true)) {
-                                vectorSize += VECTOR_OVERSIZE;
-                                while (waitingForResize < tcount - 1) {
-                                    std::this_thread::yield();
+                        const int tid = omp_get_thread_num();
+                        moved[tid]++;
+                        if (singletonMove) { // move node to empty community
+                            singleton++;
+                            movedToSingleton[tid]++;
+                            bestCommunity = upperBound++;
+                            if (bestCommunity >= communityVolumes.size()) {
+                                // Wait until all other threads yielded, then increase vector size
+                                bool expected = false;
+                                if (resize.compare_exchange_strong(expected, true)) {
+                                    vectorSize += VECTOR_OVERSIZE;
+                                    while (waitingForResize < tcount - 1) {
+                                        std::this_thread::yield();
+                                    }
+                                    // all other threads are yielding, so resize is fine
+                                    communityVolumes.resize(vectorSize);
+                                    communitySizes.resize(vectorSize);
+                                    expected = true;
+                                    resize.compare_exchange_strong(expected, false);
+                                } else {
+                                    waitingForResize++;
+                                    while (resize) {
+                                        std::this_thread::yield();
+                                    }
+                                    waitingForResize--;
                                 }
-                                // all other threads are yielding, so resize is fine
-                                communityVolumes.resize(vectorSize);
-                                communitySizes.resize(vectorSize);
-                                expected = true;
-                                resize.compare_exchange_strong(expected, false);
-                            } else {
-                                waitingForResize++;
-                                while (resize) {
-                                    std::this_thread::yield();
-                                }
-                                waitingForResize--;
                             }
                         }
-                    }
-                    gainMarginSum[tid] += gainMargin;
-                    gainMarginMin[tid] = std::min(gainMarginMin[tid], gainMargin);
-                    gainMarginMax[tid] = std::max(gainMarginMax[tid], gainMargin);
-                    result[u] = bestCommunity;
+                        gainMarginSum[tid] += gainMargin;
+                        gainMarginMin[tid] = std::min(gainMarginMin[tid], gainMargin);
+                        gainMarginMax[tid] = std::max(gainMarginMax[tid], gainMargin);
+                        result[u] = bestCommunity;
 #pragma omp atomic
-                    communityVolumes[bestCommunity] += degree;
+                        communityVolumes[bestCommunity] += degree;
 #pragma omp atomic
-                    communityVolumes[currentCommunity] -= degree;
+                        communityVolumes[currentCommunity] -= degree;
 #pragma omp atomic
-                    communitySizes[bestCommunity] += nodeMass;
+                        communitySizes[bestCommunity] += nodeMass;
 #pragma omp atomic
-                    communitySizes[currentCommunity] -= nodeMass;
-                    changed = true;
-                    bool expected = true;
-                    inQueue[u].compare_exchange_strong(expected, false);
-                    assert(expected);
-                    graph.forNeighborsOf(u, [&](node neighbor, edgeweight) {
-                        // Only add the node to the queue if it's not already
-                        // in it, and it's not the Node we're currently moving
-                        if (result[neighbor] != bestCommunity && neighbor != u) {
-                            expected = false;
-                            if (inQueue[neighbor].compare_exchange_strong(expected, true)) {
-                                newNodes.push_back(neighbor);
-                                // push new nodes to the queue in WORKING_SIZE steps
-                                if (newNodes.size() == WORKING_SIZE) {
-                                    qlock.lock();
-                                    queue.emplace(std::move(newNodes));
-                                    qlock.unlock();
-                                    // Notify threads that new is available
-                                    workAvailable.notify_all();
-                                    newNodes.clear();
-                                    newNodes.reserve(WORKING_SIZE);
-                                }
-                                assert(!expected);
+                        communitySizes[currentCommunity] -= nodeMass;
+                        changed = true;
+                        graph.forNeighborsOf(u, [&](node neighbor, edgeweight) {
+                            // Only add the node to the queue if it's not already
+                            // in it, and it's not the Node we're currently moving
+                            if (result[neighbor] != bestCommunity && neighbor != u) {
+                                scheduleNode(neighbor);
                             }
-                        }
-                    });
+                        });
                     } // if (acceptedMove)
                 }
+                finishProcessingNode(u);
             }
 
             // queue check/wait


### PR DESCRIPTION
## Summary
- Replace the Leiden move-phase boolean queue flag with an explicit per-node state machine.
- Requeue a node after processing if a neighbor moved while that node was already being processed.
- Apply the same scheduling fix to both ParallelLeiden and ParallelLeidenView.

## Root Cause
The previous inQueue flag represented multiple meanings at once: a node could be waiting in a work vector, currently being processed by a thread, or already processed but still marked as queued. That creates two lost-reprocess cases:

1. If a node is processed and does not move, inQueue stays true even though the node is no longer scheduled. A later neighbor move sees the stale true value and cannot requeue it.
2. If a neighbor moves while a node is currently being processed, the neighbor sees inQueue true and skips scheduling it. When the processing thread later clears or finishes the node, the request for another pass has already been lost.

Both cases violate the move-phase invariant that a node affected by a neighbor move should get another opportunity to evaluate its best community.

## State Machine
Each node now has one of four states:

- Idle: not scheduled and not being processed.
- Queued: scheduled in a thread-local work vector or shared queue.
- Processing: currently owned by a worker thread.
- Reprocess: currently owned by a worker thread, with at least one neighbor move requesting another pass.

Scheduling transitions:

- Idle -> Queued: a neighbor move schedules the node and pushes it to work.
- Queued -> Queued: the node is already scheduled, so no duplicate work is pushed.
- Processing -> Reprocess: the node is currently being evaluated, so record that it must be queued again when processing finishes.
- Reprocess -> Reprocess: a reprocess request is already recorded, so no duplicate work is pushed.

Processing transitions:

- Queued -> Processing: a worker starts evaluating a node it owns.
- Processing -> Idle: processing finishes and no neighbor requested another pass.
- Reprocess -> Queued: processing finishes after a neighbor requested another pass, so the same node is pushed back into work.

This preserves one queued copy per node while still remembering neighbor updates that arrive during processing.

## Validation
- git diff --check
- CI will run the full test suite.