### PR TITLE
Graph/GraphR: remove std::vector based constructors

### DIFF
--- a/include/networkit/graph/Graph.hpp
+++ b/include/networkit/graph/Graph.hpp
@@ -737,21 +737,6 @@ public:
     Graph(std::initializer_list<WeightedEdge> edges);
 
     /**
-     * Create a graph from CSR arrays for memory-efficient storage.
-     *
-     * @param n Number of nodes.
-     * @param directed If set to @c true, the graph will be directed.
-     * @param outIndices CSR indices array containing neighbor node IDs for outgoing edges
-     * @param outIndptr CSR indptr array containing offsets into outIndices for each node
-     * @param inIndices CSR indices array containing neighbor node IDs for incoming edges (directed
-     * only)
-     * @param inIndptr CSR indptr array containing offsets into inIndices for each node (directed
-     * only)
-     */
-    Graph(count n, bool directed, std::vector<node> outIndices, std::vector<index> outIndptr,
-          std::vector<node> inIndices = {}, std::vector<index> inIndptr = {});
-
-    /**
      * Create a graph as copy of @a other.
      * @param other The graph to copy.
      */

--- a/include/networkit/graph/GraphR.hpp
+++ b/include/networkit/graph/GraphR.hpp
@@ -25,23 +25,6 @@ namespace NetworKit {
 class GraphR : public Graph {
 public:
     /**
-     * Create a graph from CSR arrays for memory-efficient storage.
-     *
-     * @param n Number of nodes.
-     * @param directed If set to @c true, the graph will be directed.
-     * @param outIndices CSR indices array containing neighbor node IDs for outgoing edges
-     * @param outIndptr CSR indptr array containing offsets into outIndices for each node
-     * @param inIndices CSR indices array containing neighbor node IDs for incoming edges (directed
-     * only)
-     * @param inIndptr CSR indptr array containing offsets into inIndices for each node (directed
-     * only)
-     */
-    GraphR(count n, bool directed, std::vector<node> outIndices, std::vector<index> outIndptr,
-           std::vector<node> inIndices = {}, std::vector<index> inIndptr = {})
-        : Graph(n, directed, std::move(outIndices), std::move(outIndptr), std::move(inIndices),
-                std::move(inIndptr)) {}
-
-    /**
      * Constructor that creates a graph from Arrow CSR arrays for zero-copy memory efficiency.
      * @param n Number of nodes.
      * @param directed If set to @c true, the graph will be directed.

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -156,7 +156,6 @@ cdef extern from "<networkit/graph/GraphW.hpp>":
 
 cdef extern from "<networkit/graph/GraphR.hpp>":
 	cdef cppclass _GraphR "NetworKit::GraphR" (_Graph):
-		_GraphR(count n, bool_t directed, vector[node] outIndices, vector[index] outIndptr, vector[node] inIndices, vector[index] inIndptr) except +
 		_GraphR(count n, bool_t directed, shared_ptr[UInt64Array] outIndices, shared_ptr[UInt64Array] outIndptr, shared_ptr[UInt64Array] inIndices, shared_ptr[UInt64Array] inIndptr, shared_ptr[DoubleArray] outWeights, shared_ptr[DoubleArray] inWeights) except +
 		_GraphR(const _GraphR& other) except +
 


### PR DESCRIPTION
These are meant to be used only with GraphW