### PR TITLE
fix: include span to fix build error

### DIFF
--- a/include/networkit/structures/LeastCommonAncestor.hpp
+++ b/include/networkit/structures/LeastCommonAncestor.hpp
@@ -9,6 +9,7 @@
 #define NETWORKIT_STRUCTURES_LEAST_COMMON_ANCESTOR_HPP_
 
 #include <vector>
+#include <span>
 #include "networkit/auxiliary/RangeMinimumQuery.hpp"
 #include <networkit/Globals.hpp>
 #include <networkit/graph/Graph.hpp>


### PR DESCRIPTION
Compiling from source gives the build error:

```
icebug/include/networkit/structures/LeastCommonAncestor.hpp:54:16: error: ‘std::span’ has not been declared
```

The fix is to include the `<span>` header.