### PR TITLE
feat(centrality): add parallel k-core decomposition based on SIGMOD 2025 paper

### DIFF
--- a/examples/benchmark_parallel_core_decomposition.py
+++ b/examples/benchmark_parallel_core_decomposition.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+"""Compare the preserved ParK implementation with the SIGMOD 2025 implementation."""
+
+import argparse
+import math
+import statistics
+import time
+
+import networkit as nk
+
+
+def validate(algorithm, expected_scores, expected_max_core, name):
+    actual_scores = algorithm.scores()
+    actual_max_core = algorithm.maxCoreNumber()
+    if actual_max_core != expected_max_core:
+        raise RuntimeError(
+            f"{name} returned max core {actual_max_core}; expected {expected_max_core}")
+    if len(actual_scores) != len(expected_scores):
+        raise RuntimeError(
+            f"{name} returned {len(actual_scores)} scores; expected {len(expected_scores)}")
+    if actual_scores != expected_scores:
+        mismatch = next(
+            node for node, (expected, actual) in enumerate(zip(expected_scores, actual_scores))
+            if expected != actual)
+        raise RuntimeError(
+            f"{name} returned core {actual_scores[mismatch]} for node {mismatch}; "
+            f"expected {expected_scores[mismatch]}")
+
+
+def measure(name, factory, expected_scores, expected_max_core, repeats):
+    samples = []
+    for _ in range(repeats):
+        algorithm = factory()
+        started = time.perf_counter()
+        algorithm.run()
+        samples.append(time.perf_counter() - started)
+        validate(algorithm, expected_scores, expected_max_core, name)
+    return statistics.median(samples), samples
+
+
+def benchmark(name, graph, repeats):
+    oracle = nk.centrality.CoreDecomposition(
+        graph, normalized=False, enforceBucketQueueAlgorithm=True)
+    oracle.run()
+    expected_scores = oracle.scores()
+    expected_max_core = oracle.maxCoreNumber()
+
+    park_median, park_samples = measure(
+        "ParK", lambda: nk.centrality.CoreDecomposition(graph), expected_scores,
+        expected_max_core, repeats)
+    parallel_median, parallel_samples = measure(
+        "SIGMOD25", lambda: nk.centrality.ParallelCoreDecomposition(graph), expected_scores,
+        expected_max_core, repeats)
+
+    print(f"\n{name}: n={graph.numberOfNodes()} m={graph.numberOfEdges()}")
+    print(
+        f"validated={2 * repeats} timed runs against exact per-node scores; "
+        f"max_core={expected_max_core}")
+    print(f"ParK: median={park_median:.6f}s samples={park_samples}")
+    print(f"SIGMOD25: median={parallel_median:.6f}s samples={parallel_samples}")
+    print(f"ParK/SIGMOD25={park_median / parallel_median:.3f}x")
+
+
+def sparse_er():
+    nk.setSeed(42, False)
+    return nk.generators.ErdosRenyiGenerator(200_000, 0.00005, False).generate()
+
+
+def vgc_path():
+    graph = nk.Graph(1_000_000)
+    for node in range(1, graph.numberOfNodes()):
+        graph.addEdge(node - 1, node)
+    return graph
+
+
+def sampling_star():
+    graph = nk.Graph(1_000_001)
+    for leaf in range(1, graph.numberOfNodes()):
+        graph.addEdge(0, leaf)
+    return graph
+
+
+def sampling_bipartite():
+    graph = nk.Graph(20_020)
+    for high_degree_node in range(20):
+        for low_degree_node in range(20, graph.numberOfNodes()):
+            graph.addEdge(high_degree_node, low_degree_node)
+    return graph
+
+
+def hbs_clique():
+    return nk.generators.ErdosRenyiGenerator(2_000, 1.0, False).generate()
+
+
+def graph_from_symmetric_csr(indices, indptr):
+    """Build an undirected zero-copy GraphR from NumPy uint64 CSR storage."""
+    import pyarrow as pa
+
+    return nk.Graph.fromCSR(
+        len(indptr) - 1,
+        False,
+        pa.array(indices, type=pa.uint64()),
+        pa.array(indptr, type=pa.uint64()),
+    )
+
+
+def large_bipartite(target_edges):
+    """Build K(left, right) with exactly ``target_edges`` when divisible by left."""
+    import numpy as np
+
+    left = 1_000
+    if target_edges < left or target_edges % left:
+        raise ValueError(f"large bipartite edge count must be divisible by {left}")
+    right = target_edges // left
+    nodes = left + right
+    adjacency_entries = 2 * target_edges
+
+    indices = np.empty(adjacency_entries, dtype=np.uint64)
+    right_nodes = np.arange(left, nodes, dtype=np.uint64)
+    for node in range(left):
+        begin = node * right
+        indices[begin:begin + right] = right_nodes
+
+    left_nodes = np.arange(left, dtype=np.uint64)
+    reverse_begin = target_edges
+    rows_per_chunk = 16_384
+    for row_begin in range(0, right, rows_per_chunk):
+        row_end = min(row_begin + rows_per_chunk, right)
+        begin = reverse_begin + row_begin * left
+        end = reverse_begin + row_end * left
+        indices[begin:end].reshape(row_end - row_begin, left)[:] = left_nodes
+
+    indptr = np.empty(nodes + 1, dtype=np.uint64)
+    indptr[:left + 1] = np.arange(left + 1, dtype=np.uint64) * right
+    indptr[left + 1:] = target_edges + np.arange(1, right + 1, dtype=np.uint64) * left
+    return graph_from_symmetric_csr(indices, indptr)
+
+
+def large_clique(target_edges):
+    """Build the largest complete graph with no more than ``target_edges`` edges."""
+    import numpy as np
+
+    nodes = (1 + math.isqrt(1 + 8 * target_edges)) // 2
+    edges = nodes * (nodes - 1) // 2
+    adjacency_entries = 2 * edges
+    indices = np.empty(adjacency_entries, dtype=np.uint64)
+    all_nodes = np.arange(nodes, dtype=np.uint64)
+    row_width = nodes - 1
+    for node in range(nodes):
+        begin = node * row_width
+        indices[begin:begin + node] = all_nodes[:node]
+        indices[begin + node:begin + row_width] = all_nodes[node + 1:]
+
+    indptr = np.arange(nodes + 1, dtype=np.uint64) * row_width
+    return graph_from_symmetric_csr(indices, indptr)
+
+
+def large_sparse_er(target_edges):
+    """Build a sparse Erdos-Renyi graph with about ``target_edges`` edges."""
+    nodes = max(1_000, target_edges // 20)
+    probability = (2.0 * target_edges) / (nodes * (nodes - 1))
+    if probability > 1.0:
+        raise ValueError("large sparse ER target is too dense for the selected node count")
+    nk.setSeed(42, False)
+    return nk.generators.ErdosRenyiGenerator(nodes, probability, False).generate()
+
+
+def large_star(target_edges):
+    """Build a zero-copy star with exactly ``target_edges`` edges."""
+    import numpy as np
+
+    nodes = target_edges + 1
+    indices = np.empty(2 * target_edges, dtype=np.uint64)
+    indices[:target_edges] = np.arange(1, nodes, dtype=np.uint64)
+    indices[target_edges:] = 0
+
+    indptr = np.empty(nodes + 1, dtype=np.uint64)
+    indptr[0] = 0
+    indptr[1:] = target_edges + np.arange(nodes, dtype=np.uint64)
+    return graph_from_symmetric_csr(indices, indptr)
+
+
+def large_path(target_edges):
+    """Build a zero-copy path with exactly ``target_edges`` edges."""
+    import numpy as np
+
+    nodes = target_edges + 1
+    indices = np.empty(2 * target_edges, dtype=np.uint64)
+    indices[0] = 1
+    if nodes > 2:
+        internal_nodes = np.arange(1, nodes - 1, dtype=np.uint64)
+        indices[1:-1:2] = internal_nodes - 1
+        indices[2:-1:2] = internal_nodes + 1
+    indices[-1] = nodes - 2
+
+    indptr = np.empty(nodes + 1, dtype=np.uint64)
+    indptr[0] = 0
+    indptr[1:nodes] = 2 * np.arange(1, nodes, dtype=np.uint64) - 1
+    indptr[nodes] = 2 * target_edges
+    return graph_from_symmetric_csr(indices, indptr)
+
+
+CASES = {
+    "sparse-er": sparse_er,
+    "vgc-path": vgc_path,
+    "sampling-star": sampling_star,
+    "sampling-bipartite": sampling_bipartite,
+    "hbs-clique": hbs_clique,
+}
+
+LARGE_CASES = {
+    "large-bipartite": large_bipartite,
+    "large-clique": large_clique,
+    "large-sparse-er": large_sparse_er,
+    "large-star": large_star,
+    "large-path": large_path,
+}
+
+LARGE_ALL_CASES = ("large-bipartite", "large-clique")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case", choices=["all", "large-all", *CASES, *LARGE_CASES], default="all")
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--threads", type=int, default=15)
+    parser.add_argument(
+        "--large-edges", type=int, default=100_000_000,
+        help="target undirected edge count for large CSR cases (default: 100 million)")
+    args = parser.parse_args()
+
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+    if args.threads < 1:
+        parser.error("--threads must be positive")
+    if args.large_edges < 1:
+        parser.error("--large-edges must be positive")
+
+    nk.setNumberOfThreads(args.threads)
+    if args.case == "all":
+        selected = [(name, factory) for name, factory in CASES.items()]
+    elif args.case == "large-all":
+        selected = [(name, LARGE_CASES[name]) for name in LARGE_ALL_CASES]
+    elif args.case in LARGE_CASES:
+        selected = [(args.case, LARGE_CASES[args.case])]
+    else:
+        selected = [(args.case, CASES[args.case])]
+    for name, factory in selected:
+        graph = factory(args.large_edges) if name in LARGE_CASES else factory()
+        benchmark(name, graph, args.repeats)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/networkit/centrality/ParallelCoreDecomposition.hpp
+++ b/include/networkit/centrality/ParallelCoreDecomposition.hpp
@@ -1,0 +1,80 @@
+/*
+ * ParallelCoreDecomposition.hpp
+ *
+ * Exact shared-memory k-core decomposition based on the SIGMOD 2025 algorithm.
+ */
+
+#ifndef NETWORKIT_CENTRALITY_PARALLEL_CORE_DECOMPOSITION_HPP_
+#define NETWORKIT_CENTRALITY_PARALLEL_CORE_DECOMPOSITION_HPP_
+
+#include <networkit/centrality/Centrality.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/structures/Cover.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup centrality
+ * Computes an exact k-core decomposition in parallel.
+ *
+ * The implementation is based on the online peeling framework, hierarchical bucketing structure,
+ * probabilistic high-degree sampling, and vertical granularity control described by Liu et al. in
+ * "Parallel k-Core Decomposition: Theory and Practice" (Proc. ACM Manag. Data 3, 3, SIGMOD
+ * 2025). Sampling errors are detected and cause a restart without sampling, making the
+ * implementation Las Vegas rather than Monte Carlo.
+ *
+ * The input graph must be undirected, must not contain self-loops, and must have continuous node
+ * ids. Both GraphW and zero-copy CSR-backed GraphR inputs are supported.
+ */
+class ParallelCoreDecomposition final : public Centrality {
+public:
+    /**
+     * Create a parallel core decomposition for @a G.
+     *
+     * @param G The undirected input graph.
+     * @param normalized If @c true, divide core numbers by the maximum degree.
+     * @param useSampling If @c true, use the paper's high-degree sampling optimization.
+     */
+    ParallelCoreDecomposition(const Graph &G, bool normalized = false, bool useSampling = true);
+
+    /** Compute the core number of every node. */
+    void run() override;
+
+    /**
+     * Get the nested k-cores as a cover.
+     *
+     * @return The k-cores as a Cover.
+     */
+    Cover getCover() const;
+
+    /**
+     * Get the k-shells as a partition.
+     *
+     * @return The k-shells as a Partition.
+     */
+    Partition getPartition() const;
+
+    /** @return The maximum core number. */
+    index maxCoreNumber() const;
+
+    /**
+     * Get the number of sampling-error recovery restarts performed by the last run.
+     *
+     * @return Zero unless a sampling validation failed and the algorithm restarted without
+     * sampling.
+     */
+    count numberOfRestarts() const;
+
+    /** @return The theoretical maximum centrality score. */
+    double maximum() override;
+
+private:
+    index maxCore{0};
+    bool useSampling;
+    count restarts{0};
+};
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_CENTRALITY_PARALLEL_CORE_DECOMPOSITION_HPP_

--- a/networkit/centrality.pyx
+++ b/networkit/centrality.pyx
@@ -2276,6 +2276,56 @@ cdef class CoreDecomposition(Centrality):
 		"""
 		return (<_CoreDecomposition*>(self._this)).getNodeOrder()
 
+cdef extern from "<networkit/centrality/ParallelCoreDecomposition.hpp>":
+
+	cdef cppclass _ParallelCoreDecomposition "NetworKit::ParallelCoreDecomposition" (_Centrality):
+		_ParallelCoreDecomposition(_Graph, bool_t, bool_t) except +
+		_Cover getCover() except +
+		_Partition getPartition() except +
+		index maxCoreNumber() except +
+		count numberOfRestarts() except +
+
+cdef class ParallelCoreDecomposition(Centrality):
+	"""
+	ParallelCoreDecomposition(G, normalized=False, useSampling=True)
+
+	Computes an exact parallel k-core decomposition of an undirected graph using the SIGMOD 2025
+	online peeling algorithm with hierarchical buckets, high-degree sampling, and vertical
+	granularity control. If sampling validation detects an error, the algorithm restarts without
+	sampling to preserve exact results.
+
+	Parameters
+	----------
+	G : networkit.Graph
+		The undirected input graph. Node ids must be continuous and the graph may not contain
+		self-loops.
+	normalized : bool, optional
+		Divide each core number by the maximum degree. Default: False
+	useSampling : bool, optional
+		Use high-degree sampling to reduce atomic contention. Default: True
+	"""
+
+	def __cinit__(self, Graph G, bool_t normalized=False, bool_t useSampling=True):
+		self._G = G
+		self._this = new _ParallelCoreDecomposition(
+			dereference(G._this), normalized, useSampling)
+
+	def maxCoreNumber(self):
+		"""Return the maximum core number."""
+		return (<_ParallelCoreDecomposition*>(self._this)).maxCoreNumber()
+
+	def numberOfRestarts(self):
+		"""Return the number of sampling-error recovery restarts in the last run."""
+		return (<_ParallelCoreDecomposition*>(self._this)).numberOfRestarts()
+
+	def getCover(self):
+		"""Return the nested k-cores as a cover."""
+		return Cover().setThis((<_ParallelCoreDecomposition*>(self._this)).getCover())
+
+	def getPartition(self):
+		"""Return the k-shells as a partition."""
+		return Partition().setThis((<_ParallelCoreDecomposition*>(self._this)).getPartition())
+
 cdef extern from "<networkit/centrality/EigenvectorCentrality.hpp>":
 
 	cdef cppclass _EigenvectorCentrality "NetworKit::EigenvectorCentrality" (_Centrality):
@@ -3286,5 +3336,4 @@ cdef class ComplexPaths(Algorithm):
 
 		"""
 		return (<_ComplexPaths*>(self._this)).normalize()
-
 

--- a/networkit/cpp/centrality/CMakeLists.txt
+++ b/networkit/cpp/centrality/CMakeLists.txt
@@ -35,6 +35,7 @@ networkit_add_module(centrality
     LocalPartitionCoverage.cpp
     LocalSquareClusteringCoefficient.cpp
     PageRank.cpp
+    ParallelCoreDecomposition.cpp
     PermanenceCentrality.cpp
     Sfigality.cpp
     SpanningEdgeCentrality.cpp

--- a/networkit/cpp/centrality/ParallelCoreDecomposition.cpp
+++ b/networkit/cpp/centrality/ParallelCoreDecomposition.cpp
@@ -1,0 +1,792 @@
+/*
+ * ParallelCoreDecomposition.cpp
+ *
+ * Exact shared-memory k-core decomposition based on Liu et al., SIGMOD 2025.
+ */
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <omp.h>
+
+#include <networkit/centrality/ParallelCoreDecomposition.hpp>
+
+namespace NetworKit {
+namespace {
+
+constexpr count log2SingleBuckets = 3;
+constexpr count numSingleBuckets = count{1} << log2SingleBuckets;
+constexpr count numIntermediateBuckets = 6;
+constexpr count numBuckets = numSingleBuckets + numIntermediateBuckets;
+constexpr count bucketMask = numSingleBuckets - 1;
+constexpr count bucketStride = numSingleBuckets << numIntermediateBuckets;
+
+constexpr count sampleThreshold = 2000;
+constexpr double initialReduceRatio = 0.1;
+constexpr count log2ErrorFactor = 32;
+constexpr count baselineExpectedHits =
+    static_cast<count>(log2ErrorFactor / (initialReduceRatio * initialReduceRatio));
+constexpr double biasFactor = 0.5;
+constexpr double errorRateTolerance = 1e-10;
+
+constexpr count localQueueSize = 128;
+constexpr count neighborParallelismThreshold = 128;
+constexpr count parallelFrontierThreshold = 256;
+constexpr count hbsSwitchCore = 16;
+
+using BucketArray = std::array<std::vector<node>, numBuckets>;
+
+struct ThreadScratch final {
+    BucketArray buckets;
+    std::vector<node> recounts;
+};
+
+struct EdgeBlock final {
+    node source;
+    index begin;
+    index end;
+};
+
+uint32_t hash32(uint32_t value) {
+    value = (value + 0x7ed55d16U) + (value << 12);
+    value = (value ^ 0xc761c23cU) ^ (value >> 19);
+    value = (value + 0x165667b1U) + (value << 5);
+    value = (value + 0xd3a2646cU) ^ (value << 9);
+    value = (value + 0xfd7046c5U) + (value << 3);
+    value = (value ^ 0xb55a4f09U) ^ (value >> 16);
+    return value;
+}
+
+count log2Up(count value) {
+    if (value <= 1) {
+        return 0;
+    }
+
+    count result = 0;
+    --value;
+    while (value > 0) {
+        ++result;
+        value >>= 1;
+    }
+    return result;
+}
+
+count mostSignificantBit(count value) {
+    count result = 0;
+    while (value >>= 1) {
+        ++result;
+    }
+    return result;
+}
+
+class Sampler final {
+public:
+    void reset(count newExpectedHits, double newRate) {
+        expectedHits = newExpectedHits;
+        rate = std::min(1.0, newRate);
+        threshold =
+            static_cast<uint32_t>(rate * static_cast<double>(std::numeric_limits<uint32_t>::max()));
+        hits.store(0, std::memory_order_relaxed);
+    }
+
+    bool sample(uint32_t randomNumber) {
+        count current = hits.load(std::memory_order_relaxed);
+        if (current >= expectedHits || randomNumber >= threshold) {
+            return false;
+        }
+
+        current = hits.fetch_add(1, std::memory_order_relaxed);
+        return current + 1 == expectedHits;
+    }
+
+    count numberOfHits() const { return hits.load(std::memory_order_relaxed); }
+
+    count numberOfExpectedHits() const { return expectedHits; }
+
+    double sampleRate() const { return rate; }
+
+private:
+    std::atomic<count> hits{0};
+    count expectedHits{0};
+    uint32_t threshold{0};
+    double rate{0.0};
+};
+
+class ParallelKCoreSolver final {
+public:
+    ParallelKCoreSolver(const Graph &G, std::vector<double> &scores, bool samplingEnabled)
+        : G(G), scores(scores), samplingEnabled(samplingEnabled), z(G.upperNodeIdBound()),
+          degrees(new std::atomic<count>[z]), samplers(new Sampler[z]),
+          recountQueued(new std::atomic<bool>[z]), active(z, 1), sampleMode(z, 0),
+          threadScratch(omp_get_max_threads()), filterCounts(omp_get_max_threads()),
+          filterOffsets(omp_get_max_threads()), seenAtEpoch(z, 0) {
+        for (node u = 0; u < z; ++u) {
+            recountQueued[u].store(false, std::memory_order_relaxed);
+        }
+    }
+
+    bool run() {
+        const count n = G.numberOfNodes();
+        if (n == 0) {
+            return true;
+        }
+
+        initialize();
+
+        std::vector<node> remaining(z);
+#pragma omp parallel for schedule(static)
+        for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
+            remaining[u] = static_cast<node>(u);
+        }
+
+        const count averageDegree = G.numberOfEdges() * 2 / n;
+        count firstHbsLevel = 0;
+        if (averageDegree < hbsSwitchCore) {
+            for (count level = 0; level < hbsSwitchCore && !remaining.empty(); ++level) {
+                buckets[0].clear();
+                if (!buildSparseBucket(remaining, level)) {
+                    return false;
+                }
+                if (!processLevel(level, level, false)) {
+                    return false;
+                }
+                filterRemaining(remaining);
+                firstHbsLevel = level + 1;
+            }
+        }
+
+        for (count baseLevel = 0; !remaining.empty(); baseLevel += bucketStride) {
+            if (baseLevel > maximumInitialDegree) {
+                return false;
+            }
+
+            clearBuckets();
+            const count levelBegin = std::max(baseLevel, firstHbsLevel);
+            if (!buildBuckets(remaining, levelBegin, baseLevel + bucketStride, baseLevel, true)) {
+                return false;
+            }
+
+            for (count level = levelBegin; level < baseLevel + bucketStride && !remaining.empty();
+                 ++level) {
+                if (level != baseLevel && (level & bucketMask) == 0) {
+                    redistributeIntermediateBucket(level);
+                }
+
+                const count bucketBase = level & ~bucketMask;
+                if (!processLevel(level, bucketBase, true)) {
+                    return false;
+                }
+            }
+
+            filterRemaining(remaining);
+        }
+
+        return true;
+    }
+
+    index maxCoreNumber() const { return maxCore; }
+
+private:
+    const Graph &G;
+    std::vector<double> &scores;
+    bool samplingEnabled;
+    count z;
+    std::unique_ptr<std::atomic<count>[]> degrees;
+    std::unique_ptr<Sampler[]> samplers;
+    std::unique_ptr<std::atomic<bool>[]> recountQueued;
+    std::vector<char> active;
+    std::vector<char> sampleMode;
+    BucketArray buckets;
+    std::vector<ThreadScratch> threadScratch;
+    std::vector<count> filterCounts;
+    std::vector<count> filterOffsets;
+    std::vector<node> filterBuffer;
+    std::vector<count> seenAtEpoch;
+    count scratchInUse{1};
+    bool samplingPossible{false};
+    count currentEpoch{0};
+    index maxCore{0};
+    count maximumInitialDegree{0};
+
+    void initialize() {
+        count maxDegree = 0;
+#pragma omp parallel for reduction(max : maxDegree) schedule(static)
+        for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
+            const count degree = G.degree(static_cast<node>(u));
+            degrees[u].store(degree, std::memory_order_relaxed);
+            maxDegree = std::max(maxDegree, degree);
+        }
+        maximumInitialDegree = maxDegree;
+        samplingPossible = samplingEnabled && maxDegree * initialReduceRatio >= sampleThreshold;
+
+        if (samplingPossible) {
+#pragma omp parallel for schedule(static)
+            for (omp_index u = 0; u < static_cast<omp_index>(z); ++u) {
+                setSampler(static_cast<node>(u), 0);
+            }
+        }
+    }
+
+    void setSampler(node u, count level) {
+        if (!samplingPossible) {
+            sampleMode[u] = 0;
+            return;
+        }
+
+        const count degree = degrees[u].load(std::memory_order_relaxed);
+        const double reducedDegree = degree * initialReduceRatio;
+        const double remainingAfterReduction =
+            (degree - std::min(degree, level)) * (1.0 - initialReduceRatio);
+
+        if (reducedDegree >= sampleThreshold && level < reducedDegree * biasFactor
+            && baselineExpectedHits < remainingAfterReduction) {
+            sampleMode[u] = 1;
+            const count distance = degree - level;
+            const count logarithm = log2Up(distance);
+            const count expectedHits = log2ErrorFactor * logarithm * logarithm / 2;
+            const double rate = expectedHits / ((1.0 - initialReduceRatio) * degree);
+            samplers[u].reset(expectedHits, rate);
+        } else {
+            sampleMode[u] = 0;
+        }
+    }
+
+    bool sampleIsSafe(node u, count horizon) const {
+        const count degree = degrees[u].load(std::memory_order_relaxed);
+        if (degree * initialReduceRatio * biasFactor < horizon || degree <= horizon) {
+            return false;
+        }
+
+        const double rate = samplers[u].sampleRate();
+        const double distance = static_cast<double>(degree - horizon);
+        const double expected = distance * rate;
+        if (expected <= 0.0) {
+            return false;
+        }
+
+        const double hits = static_cast<double>(std::max<count>(1, samplers[u].numberOfHits()));
+        const double exponent = -expected + 2.0 * hits - hits * hits / expected;
+        return std::exp(exponent) < errorRateTolerance;
+    }
+
+    template <typename Buckets>
+    void addToBucket(Buckets &target, node u, count degree, count baseLevel) {
+        if (degree < baseLevel || degree >= baseLevel + bucketStride) {
+            return;
+        }
+
+        if (degree < baseLevel + numSingleBuckets) {
+            target[degree & bucketMask].push_back(u);
+            return;
+        }
+
+        const count differingBit = mostSignificantBit(degree ^ baseLevel);
+        const count bucket = numSingleBuckets + differingBit - log2SingleBuckets;
+        target[bucket].push_back(u);
+    }
+
+    template <typename Buckets>
+    void moveBucket(Buckets &target, node u, count degree, count baseLevel) {
+        if (degree < baseLevel || degree >= baseLevel + bucketStride) {
+            return;
+        }
+
+        if (degree < baseLevel + numSingleBuckets) {
+            target[degree & bucketMask].push_back(u);
+            return;
+        }
+
+        const count differingBit = mostSignificantBit(degree ^ baseLevel);
+        const count previousDifferingBit = mostSignificantBit((degree + 1) ^ baseLevel);
+        if (differingBit != previousDifferingBit) {
+            const count bucket = numSingleBuckets + differingBit - log2SingleBuckets;
+            target[bucket].push_back(u);
+        }
+    }
+
+    void resetScratch(count numberOfThreads) {
+        for (count thread = 0; thread < numberOfThreads; ++thread) {
+            auto &scratch = threadScratch[thread];
+            scratch.recounts.clear();
+            for (auto &bucket : scratch.buckets) {
+                bucket.clear();
+            }
+        }
+    }
+
+    void mergeScratchBuckets(count numberOfThreads) {
+        for (count thread = 0; thread < numberOfThreads; ++thread) {
+            auto &scratch = threadScratch[thread];
+            for (count bucket = 0; bucket < numBuckets; ++bucket) {
+                auto &source = scratch.buckets[bucket];
+                buckets[bucket].insert(buckets[bucket].end(), source.begin(), source.end());
+            }
+        }
+    }
+
+    std::vector<node> collectScratchRecounts(count numberOfThreads) {
+        count size = 0;
+        for (count thread = 0; thread < numberOfThreads; ++thread) {
+            size += threadScratch[thread].recounts.size();
+        }
+
+        std::vector<node> recounts;
+        recounts.reserve(size);
+        for (count thread = 0; thread < numberOfThreads; ++thread) {
+            const auto &source = threadScratch[thread].recounts;
+            recounts.insert(recounts.end(), source.begin(), source.end());
+        }
+        return recounts;
+    }
+
+    void clearBuckets() {
+        for (auto &bucket : buckets) {
+            bucket.clear();
+        }
+    }
+
+    bool buildBuckets(const std::vector<node> &remaining, count level, count horizon,
+                      count baseLevel, bool useHbs) {
+        resetScratch(threadScratch.size());
+#pragma omp parallel for schedule(static)
+        for (omp_index i = 0; i < static_cast<omp_index>(remaining.size()); ++i) {
+            const node u = remaining[i];
+            const count degree = degrees[u].load(std::memory_order_relaxed);
+            auto &scratch = threadScratch[omp_get_thread_num()];
+            addToBucket(scratch.buckets, u, degree, baseLevel);
+            if (samplingPossible && sampleMode[u] && !sampleIsSafe(u, horizon)) {
+                bool expected = false;
+                if (recountQueued[u].compare_exchange_strong(expected, true,
+                                                             std::memory_order_relaxed)) {
+                    scratch.recounts.push_back(u);
+                }
+            }
+        }
+        mergeScratchBuckets(threadScratch.size());
+        return recountVertices(collectScratchRecounts(threadScratch.size()), level, baseLevel,
+                               useHbs);
+    }
+
+    bool buildSparseBucket(const std::vector<node> &remaining, count level) {
+        resetScratch(threadScratch.size());
+#pragma omp parallel for schedule(static)
+        for (omp_index i = 0; i < static_cast<omp_index>(remaining.size()); ++i) {
+            const node u = remaining[i];
+            const count degree = degrees[u].load(std::memory_order_relaxed);
+            auto &scratch = threadScratch[omp_get_thread_num()];
+            if (degree == level) {
+                scratch.buckets[0].push_back(u);
+            }
+            if (samplingPossible && sampleMode[u] && !sampleIsSafe(u, level + bucketStride)) {
+                bool expected = false;
+                if (recountQueued[u].compare_exchange_strong(expected, true,
+                                                             std::memory_order_relaxed)) {
+                    scratch.recounts.push_back(u);
+                }
+            }
+        }
+        mergeScratchBuckets(threadScratch.size());
+        return recountVertices(collectScratchRecounts(threadScratch.size()), level, level, false);
+    }
+
+    std::vector<node> uniqueActive(std::vector<node> candidates) {
+        ++currentEpoch;
+        if (currentEpoch == 0) {
+            std::fill(seenAtEpoch.begin(), seenAtEpoch.end(), 0);
+            ++currentEpoch;
+        }
+
+        size_t output = 0;
+        for (node u : candidates) {
+            if (active[u] && seenAtEpoch[u] != currentEpoch) {
+                seenAtEpoch[u] = currentEpoch;
+                candidates[output++] = u;
+            }
+        }
+        candidates.resize(output);
+        return candidates;
+    }
+
+    std::vector<node> takeExactBucket(count level, bool useHbs) {
+        const count bucket = useHbs ? (level & bucketMask) : 0;
+        std::vector<node> candidates;
+        candidates.swap(buckets[bucket]);
+        candidates = uniqueActive(std::move(candidates));
+
+        candidates.erase(std::remove_if(candidates.begin(), candidates.end(),
+                                        [&](node u) {
+                                            return degrees[u].load(std::memory_order_relaxed)
+                                                   != level;
+                                        }),
+                         candidates.end());
+        return candidates;
+    }
+
+    void redistributeIntermediateBucket(count level) {
+        count intermediate = numIntermediateBuckets;
+        for (count i = numIntermediateBuckets; i-- > 0;) {
+            const count mask = (numSingleBuckets << i) - 1;
+            if ((level & mask) == 0) {
+                intermediate = i;
+                break;
+            }
+        }
+        if (intermediate == numIntermediateBuckets) {
+            return;
+        }
+
+        const count bucket = numSingleBuckets + intermediate;
+        std::vector<node> candidates;
+        candidates.swap(buckets[bucket]);
+        candidates = uniqueActive(std::move(candidates));
+
+        resetScratch(threadScratch.size());
+#pragma omp parallel for schedule(static)
+        for (omp_index i = 0; i < static_cast<omp_index>(candidates.size()); ++i) {
+            const node u = candidates[i];
+            const count degree = degrees[u].load(std::memory_order_relaxed);
+            addToBucket(threadScratch[omp_get_thread_num()].buckets, u, degree, level);
+        }
+        mergeScratchBuckets(threadScratch.size());
+    }
+
+    void decrementNeighbor(node source, node target, count level, count bucketBase, bool useHbs,
+                           bool allowLocalQueue, std::array<node, localQueueSize> &localQueue,
+                           count &rear, BucketArray &localBuckets,
+                           std::vector<node> &localRecounts) {
+        count oldDegree = degrees[target].load(std::memory_order_relaxed);
+        if (oldDegree <= level) {
+            return;
+        }
+
+        if (samplingEnabled && sampleMode[target]) {
+            const uint32_t key = static_cast<uint32_t>(source * z + target);
+            if (samplers[target].sample(hash32(key))) {
+                bool expected = false;
+                if (recountQueued[target].compare_exchange_strong(expected, true,
+                                                                  std::memory_order_relaxed)) {
+                    localRecounts.push_back(target);
+                }
+            }
+            return;
+        }
+
+        while (oldDegree > level) {
+            if (degrees[target].compare_exchange_weak(oldDegree, oldDegree - 1,
+                                                      std::memory_order_relaxed)) {
+                const count newDegree = oldDegree - 1;
+                if (newDegree == level && allowLocalQueue && rear < localQueueSize) {
+                    localQueue[rear++] = target;
+                } else if (useHbs) {
+                    moveBucket(localBuckets, target, newDegree, bucketBase);
+                } else if (newDegree == level) {
+                    localBuckets[0].push_back(target);
+                }
+                return;
+            }
+        }
+    }
+
+    count processRootSequential(node root, count level, count bucketBase, bool useHbs,
+                                bool deferHighDegree, ThreadScratch &scratch) {
+        std::array<node, localQueueSize> localQueue;
+        count front = 0;
+        count rear = 1;
+        count processed = 0;
+        localQueue[0] = root;
+
+        while (front < rear) {
+            const node u = localQueue[front++];
+            if (!active[u]) {
+                continue;
+            }
+
+            if (deferHighDegree && G.degree(u) >= neighborParallelismThreshold) {
+                const count bucket = useHbs ? (level & bucketMask) : 0;
+                scratch.buckets[bucket].push_back(u);
+                continue;
+            }
+
+            active[u] = 0;
+            scores[u] = level;
+            ++processed;
+            G.forNeighborsOf(u, [&](node v) {
+                decrementNeighbor(u, v, level, bucketBase, useHbs, true, localQueue, rear,
+                                  scratch.buckets, scratch.recounts);
+            });
+        }
+        return processed;
+    }
+
+    count processLargeFrontier(const std::vector<node> &frontier, count level, count bucketBase,
+                               bool useHbs) {
+        scratchInUse = threadScratch.size();
+        resetScratch(scratchInUse);
+        count processed = 0;
+#pragma omp parallel for schedule(dynamic, 64) reduction(+ : processed)
+        for (omp_index i = 0; i < static_cast<omp_index>(frontier.size()); ++i) {
+            auto &scratch = threadScratch[omp_get_thread_num()];
+            processed +=
+                processRootSequential(frontier[i], level, bucketBase, useHbs, false, scratch);
+        }
+        mergeScratchBuckets(scratchInUse);
+        return processed;
+    }
+
+    count processSmallFrontier(const std::vector<node> &frontier, count level, count bucketBase,
+                               bool useHbs) {
+        std::vector<node> highDegreeRoots;
+        for (node root : frontier) {
+            if (G.degree(root) >= neighborParallelismThreshold) {
+                highDegreeRoots.push_back(root);
+            }
+        }
+
+        scratchInUse = highDegreeRoots.empty() ? 1 : threadScratch.size();
+        resetScratch(scratchInUse);
+        count processed = 0;
+        for (node root : frontier) {
+            if (G.degree(root) < neighborParallelismThreshold) {
+                processed +=
+                    processRootSequential(root, level, bucketBase, useHbs, true, threadScratch[0]);
+            }
+        }
+
+        std::vector<EdgeBlock> edgeBlocks;
+        for (node root : highDegreeRoots) {
+            if (!active[root]) {
+                continue;
+            }
+
+            active[root] = 0;
+            scores[root] = level;
+            ++processed;
+            const count degree = G.degree(root);
+            for (index begin = 0; begin < degree; begin += neighborParallelismThreshold) {
+                edgeBlocks.push_back(
+                    {root, begin, std::min<index>(degree, begin + neighborParallelismThreshold)});
+            }
+        }
+
+        if (!edgeBlocks.empty()) {
+#pragma omp parallel
+            {
+                auto &scratch = threadScratch[omp_get_thread_num()];
+                std::array<node, localQueueSize> unusedQueue;
+                count unusedRear = 0;
+#pragma omp for schedule(dynamic, 8)
+                for (omp_index blockIndex = 0;
+                     blockIndex < static_cast<omp_index>(edgeBlocks.size()); ++blockIndex) {
+                    const auto &block = edgeBlocks[blockIndex];
+                    for (index neighborIndex = block.begin; neighborIndex < block.end;
+                         ++neighborIndex) {
+                        const node v = G.getIthNeighbor(Unsafe{}, block.source, neighborIndex);
+                        decrementNeighbor(block.source, v, level, bucketBase, useHbs, false,
+                                          unusedQueue, unusedRear, scratch.buckets,
+                                          scratch.recounts);
+                    }
+                }
+            }
+        }
+
+        mergeScratchBuckets(scratchInUse);
+        return processed;
+    }
+
+    bool processLevel(count level, count bucketBase, bool useHbs) {
+        std::vector<node> frontier = takeExactBucket(level, useHbs);
+        while (!frontier.empty()) {
+            const count processed = frontier.size() > parallelFrontierThreshold
+                                        ? processLargeFrontier(frontier, level, bucketBase, useHbs)
+                                        : processSmallFrontier(frontier, level, bucketBase, useHbs);
+            if (processed > 0) {
+                maxCore = std::max<index>(maxCore, level);
+            }
+
+            const std::vector<node> recounts = collectScratchRecounts(scratchInUse);
+            if (!recounts.empty() && !recountVertices(recounts, level, bucketBase, useHbs)) {
+                return false;
+            }
+            frontier = takeExactBucket(level, useHbs);
+        }
+        return true;
+    }
+
+    bool recountVertices(const std::vector<node> &vertices, count level, count bucketBase,
+                         bool useHbs) {
+        if (vertices.empty()) {
+            return true;
+        }
+
+        std::atomic<bool> samplingError{false};
+        resetScratch(threadScratch.size());
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (omp_index i = 0; i < static_cast<omp_index>(vertices.size()); ++i) {
+            const node u = vertices[i];
+            recountQueued[u].store(false, std::memory_order_relaxed);
+            if (!active[u]) {
+                continue;
+            }
+
+            count exactDegree = 0;
+            G.forNeighborsOf(u, [&](node v) { exactDegree += active[v] != 0; });
+
+            if (exactDegree < level) {
+                count previousRoundDegree = 0;
+                G.forNeighborsOf(u, [&](node v) {
+                    previousRoundDegree +=
+                        active[v] || degrees[v].load(std::memory_order_relaxed) == level;
+                });
+
+                if (previousRoundDegree < level) {
+                    samplingError.store(true, std::memory_order_relaxed);
+                    continue;
+                }
+                exactDegree = level;
+            }
+
+            degrees[u].store(exactDegree, std::memory_order_relaxed);
+            auto &scratch = threadScratch[omp_get_thread_num()];
+            if (exactDegree == level) {
+                const count bucket = useHbs ? (level & bucketMask) : 0;
+                scratch.buckets[bucket].push_back(u);
+            } else if (useHbs) {
+                addToBucket(scratch.buckets, u, exactDegree, bucketBase);
+            }
+            setSampler(u, level);
+        }
+
+        mergeScratchBuckets(threadScratch.size());
+        return !samplingError.load(std::memory_order_relaxed);
+    }
+
+    void filterRemaining(std::vector<node> &remaining) {
+        const count inputSize = remaining.size();
+        filterBuffer.resize(inputSize);
+        count outputSize = 0;
+
+#pragma omp parallel shared(outputSize)
+        {
+            const int thread = omp_get_thread_num();
+            const int threadCount = omp_get_num_threads();
+            const count begin = inputSize * thread / threadCount;
+            const count end = inputSize * (thread + 1) / threadCount;
+            count localCount = 0;
+            for (count i = begin; i < end; ++i) {
+                localCount += active[remaining[i]] != 0;
+            }
+            filterCounts[thread] = localCount;
+
+#pragma omp barrier
+#pragma omp single
+            {
+                outputSize = 0;
+                for (int owner = 0; owner < threadCount; ++owner) {
+                    filterOffsets[owner] = outputSize;
+                    outputSize += filterCounts[owner];
+                }
+            }
+#pragma omp barrier
+
+            count output = filterOffsets[thread];
+            for (count i = begin; i < end; ++i) {
+                const node u = remaining[i];
+                if (active[u]) {
+                    filterBuffer[output++] = u;
+                }
+            }
+        }
+
+        filterBuffer.resize(outputSize);
+        remaining.swap(filterBuffer);
+    }
+};
+
+} // namespace
+
+ParallelCoreDecomposition::ParallelCoreDecomposition(const Graph &G, bool normalized,
+                                                     bool useSampling)
+    : Centrality(G, normalized), useSampling(useSampling) {
+    if (G.isDirected()) {
+        throw std::runtime_error("ParallelCoreDecomposition requires an undirected graph");
+    }
+    if (G.numberOfSelfLoops()) {
+        throw std::runtime_error("ParallelCoreDecomposition does not support self-loops; call "
+                                 "Graph.removeSelfLoops() first");
+    }
+    if (G.numberOfNodes() != G.upperNodeIdBound()) {
+        throw std::runtime_error("ParallelCoreDecomposition requires continuous node ids");
+    }
+}
+
+void ParallelCoreDecomposition::run() {
+    scoreData.assign(G.upperNodeIdBound(), 0.0);
+    restarts = 0;
+
+    ParallelKCoreSolver solver(G, scoreData, useSampling);
+    if (!solver.run()) {
+        ++restarts;
+        scoreData.assign(G.upperNodeIdBound(), 0.0);
+        ParallelKCoreSolver exactSolver(G, scoreData, false);
+        if (!exactSolver.run()) {
+            throw std::runtime_error("ParallelCoreDecomposition exact recovery run failed");
+        }
+        maxCore = exactSolver.maxCoreNumber();
+    } else {
+        maxCore = solver.maxCoreNumber();
+    }
+
+    if (normalized) {
+        count maximumDegree = 0;
+        G.forNodes([&](node u) { maximumDegree = std::max(maximumDegree, G.degree(u)); });
+        if (maximumDegree > 0) {
+            G.parallelForNodes([&](node u) { scoreData[u] /= maximumDegree; });
+        }
+    }
+
+    hasRun = true;
+}
+
+Cover ParallelCoreDecomposition::getCover() const {
+    assureFinished();
+    Cover result(G.upperNodeIdBound());
+    result.setUpperBound(G.upperNodeIdBound());
+    G.forNodes([&](node u) {
+        for (index core = 0; core <= scoreData[u]; ++core) {
+            result.addToSubset(core, u);
+        }
+    });
+    return result;
+}
+
+Partition ParallelCoreDecomposition::getPartition() const {
+    assureFinished();
+    Partition result(G.upperNodeIdBound());
+    result.allToSingletons();
+    G.forNodes([&](node u) { result.moveToSubset(static_cast<index>(scoreData[u]), u); });
+    return result;
+}
+
+index ParallelCoreDecomposition::maxCoreNumber() const {
+    assureFinished();
+    return maxCore;
+}
+
+count ParallelCoreDecomposition::numberOfRestarts() const {
+    assureFinished();
+    return restarts;
+}
+
+double ParallelCoreDecomposition::maximum() {
+    return G.numberOfNodes() > 0 ? static_cast<double>(G.numberOfNodes() - 1) : 0.0;
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/centrality/test/CentralityGTest.cpp
+++ b/networkit/cpp/centrality/test/CentralityGTest.cpp
@@ -45,6 +45,7 @@
 #include <networkit/centrality/LocalPartitionCoverage.hpp>
 #include <networkit/centrality/LocalSquareClusteringCoefficient.hpp>
 #include <networkit/centrality/PageRank.hpp>
+#include <networkit/centrality/ParallelCoreDecomposition.hpp>
 #include <networkit/centrality/PermanenceCentrality.hpp>
 #include <networkit/centrality/Sfigality.hpp>
 #include <networkit/centrality/SpanningEdgeCentrality.hpp>
@@ -1520,6 +1521,44 @@ TEST_F(CentralityGTest, testCoreDecomposition) {
     H.addEdge(0, 1);
     H.addEdge(1, 1);
     EXPECT_ANY_THROW(CoreDecomposition CoreDec(H));
+}
+
+TEST_F(CentralityGTest, testParallelCoreDecompositionMatchesSequentialOracle) {
+    Aux::Random::setSeed(42, false);
+    GraphW G = ErdosRenyiGenerator(1000, 0.02, false).generate();
+
+    CoreDecomposition reference(G, false, true);
+    reference.run();
+
+    ParallelCoreDecomposition parallel(G);
+    parallel.run();
+
+    EXPECT_EQ(reference.scores(), parallel.scores());
+    EXPECT_EQ(reference.maxCoreNumber(), parallel.maxCoreNumber());
+    EXPECT_EQ(0u, parallel.numberOfRestarts());
+}
+
+TEST_F(CentralityGTest, testParallelCoreDecompositionHierarchicalBuckets) {
+    GraphW G = ErdosRenyiGenerator(520, 1.0, false).generate();
+    ParallelCoreDecomposition parallel(G);
+    parallel.run();
+
+    EXPECT_EQ(519u, parallel.maxCoreNumber());
+    G.forNodes([&](node u) { EXPECT_EQ(519, parallel.score(u)); });
+}
+
+TEST_F(CentralityGTest, testParallelCoreDecompositionSampling) {
+    GraphW G(25001);
+    for (node leaf = 1; leaf < G.numberOfNodes(); ++leaf) {
+        G.addEdge(0, leaf);
+    }
+
+    ParallelCoreDecomposition parallel(G);
+    parallel.run();
+
+    EXPECT_EQ(1u, parallel.maxCoreNumber());
+    G.forNodes([&](node u) { EXPECT_EQ(1, parallel.score(u)); });
+    EXPECT_EQ(0u, parallel.numberOfRestarts());
 }
 
 TEST_F(CentralityGTest, benchCoreDecompositionLocal) {

--- a/networkit/test/test_centrality.py
+++ b/networkit/test/test_centrality.py
@@ -105,6 +105,92 @@ class TestCentrality(unittest.TestCase):
 			CLL = nk.centrality.CoreDecomposition(tmp)
 			CLL.run()
 			self.assertTrue(self.checkCovers(CL.getCover(),CLL.getCover()))
+
+	def assertParallelCoreMatchesReference(self, graph, use_sampling=True):
+		reference = nk.centrality.CoreDecomposition(
+			graph, normalized=False, enforceBucketQueueAlgorithm=True)
+		reference.run()
+		parallel = nk.centrality.ParallelCoreDecomposition(
+			graph, normalized=False, useSampling=use_sampling)
+		parallel.run()
+		self.assertListEqual(reference.scores(), parallel.scores())
+		self.assertEqual(reference.maxCoreNumber(), parallel.maxCoreNumber())
+		return parallel
+
+	def testParallelCoreDecompositionRandomGraphs(self):
+		for seed, probability in [(1, 0.01), (2, 0.05), (3, 0.2), (4, 0.6)]:
+			nk.setSeed(seed, False)
+			graph = nk.generators.ErdosRenyiGenerator(300, probability, False).generate()
+			self.assertParallelCoreMatchesReference(graph)
+
+	def testParallelCoreDecompositionHierarchicalBuckets(self):
+		graph = nk.generators.ErdosRenyiGenerator(520, 1.0, False).generate()
+		parallel = self.assertParallelCoreMatchesReference(graph)
+		self.assertEqual(parallel.maxCoreNumber(), 519)
+
+	def testParallelCoreDecompositionSampling(self):
+		graph = nk.Graph(25001)
+		for leaf in range(1, graph.numberOfNodes()):
+			graph.addEdge(0, leaf)
+		parallel = self.assertParallelCoreMatchesReference(graph)
+		self.assertEqual(parallel.numberOfRestarts(), 0)
+
+	def testParallelCoreDecompositionSamplingDenseBipartite(self):
+		high_degree_nodes = 20
+		low_degree_nodes = 20000
+		graph = nk.Graph(high_degree_nodes + low_degree_nodes)
+		for high_degree_node in range(high_degree_nodes):
+			for low_degree_node in range(high_degree_nodes, graph.numberOfNodes()):
+				graph.addEdge(high_degree_node, low_degree_node)
+		parallel = self.assertParallelCoreMatchesReference(graph)
+		self.assertEqual(parallel.maxCoreNumber(), high_degree_nodes)
+		self.assertEqual(parallel.numberOfRestarts(), 0)
+
+	def testParallelCoreDecompositionWithoutSampling(self):
+		nk.setSeed(5, False)
+		graph = nk.generators.ErdosRenyiGenerator(500, 0.15, False).generate()
+		parallel = self.assertParallelCoreMatchesReference(graph, use_sampling=False)
+		self.assertEqual(parallel.numberOfRestarts(), 0)
+
+	def testParallelCoreDecompositionGraphR(self):
+		import pyarrow as pa
+
+		indices = pa.array([1, 2, 0, 2, 0, 1, 3, 2], type=pa.uint64())
+		indptr = pa.array([0, 2, 4, 7, 8], type=pa.uint64())
+		graph = nk.Graph.fromCSR(4, False, indices, indptr)
+		parallel = self.assertParallelCoreMatchesReference(graph)
+		self.assertListEqual(parallel.scores(), [2.0, 2.0, 2.0, 1.0])
+
+	def testParallelCoreDecompositionGraphRSampling(self):
+		import pyarrow as pa
+
+		number_of_leaves = 25000
+		indices = pa.array(
+			list(range(1, number_of_leaves + 1)) + [0] * number_of_leaves,
+			type=pa.uint64())
+		indptr = pa.array(
+			[0, number_of_leaves]
+			+ list(range(number_of_leaves + 1, 2 * number_of_leaves + 1)),
+			type=pa.uint64())
+		graph = nk.Graph.fromCSR(number_of_leaves + 1, False, indices, indptr)
+		parallel = self.assertParallelCoreMatchesReference(graph)
+		self.assertEqual(parallel.maxCoreNumber(), 1)
+		self.assertEqual(parallel.numberOfRestarts(), 0)
+
+	def testParallelCoreDecompositionRejectsUnsupportedGraphs(self):
+		directed = nk.Graph(3, False, True)
+		with self.assertRaises(RuntimeError):
+			nk.centrality.ParallelCoreDecomposition(directed)
+
+		self_loop = nk.Graph(3)
+		self_loop.addEdge(0, 0)
+		with self.assertRaises(RuntimeError):
+			nk.centrality.ParallelCoreDecomposition(self_loop)
+
+		non_continuous = nk.Graph(3)
+		non_continuous.removeNode(1)
+		with self.assertRaises(RuntimeError):
+			nk.centrality.ParallelCoreDecomposition(non_continuous)
    
 	def testComplexPathsAllNodes(self):
 		CP = nk.centrality.ComplexPaths(self.L, 3)


### PR DESCRIPTION
# Add exact parallel k-core decomposition

## Summary

This PR adds `ParallelCoreDecomposition`, a new exact shared-memory k-core implementation inspired
by the online peeling techniques from Liu et al., "Parallel k-Core Decomposition: Theory and
Practice" (SIGMOD 2025).

The existing `CoreDecomposition`/ParK implementation remains unchanged. Callers can explicitly
select either implementation and compare their behavior.

## Implementation

The new C++/OpenMP implementation includes:

- Online parallel peeling with atomic bounded degree updates
- Hierarchical buckets for skipping ranges of empty core levels
- High-degree sampling to reduce atomic contention
- Exact recounting and sampling-security checks
- Las Vegas recovery by restarting without sampling if validation fails
- Vertical granularity control using worker-local queues
- Flattened edge blocks for parallel processing of high-degree vertices
- Parallel remaining-vertex compaction
- Support for mutable `GraphW` and zero-copy Arrow CSR-backed `GraphR`

The implementation preserves exactness: sampling only reduces intermediate degree-update work and
does not approximate the final core numbers.

## API

```python
algorithm = nk.centrality.ParallelCoreDecomposition(
    graph,
    normalized=False,
    useSampling=True,
).run()

core_numbers = algorithm.scores()
maximum_core = algorithm.maxCoreNumber()
restarts = algorithm.numberOfRestarts()
shells = algorithm.getPartition()
cores = algorithm.getCover()
```

The input graph must:

- Be undirected
- Have continuous node IDs
- Not contain self-loops

## Correctness

Every benchmark execution is validated against Icebug's exact sequential bucket-queue
decomposition. Validation compares:

- The complete per-node core-number vector
- The maximum core number

Validation and graph construction are outside the measured timing interval.

Test coverage includes:

- Random graphs compared with the exact oracle
- Hierarchical-bucket execution
- High-degree sampling
- Sampling-disabled execution
- Dense bipartite graphs
- Mutable `GraphW` inputs
- Arrow CSR-backed `GraphR` inputs
- Invalid directed, self-loop, and non-continuous graphs
- Execution with 1, 2, 4, and 15 OpenMP threads

Verified results:

- 55 Python centrality tests passed
- All focused C++ tests passed at each tested thread count

## Performance

Benchmarks were run on an Apple M3 Max with 15 OpenMP threads using five repetitions. Only `run()`
was timed.

### High-contention workloads

| Graph | Edges | Existing ParK | New implementation | Result |
|---|---:|---:|---:|---:|
| Complete bipartite K(1,000, 100,000) | 100,000,000 | 200.85 ms | 93.50 ms | 2.15x faster |
| Complete graph K(14,142) | 99,991,011 | 889.68 ms | 105.50 ms | 8.43x faster |

### Low-coreness workloads

| Graph | Edges | Existing ParK | New implementation | Result |
|---|---:|---:|---:|---:|
| Sparse Erdos-Renyi | 100,024,345 | 374.31 ms | 500.84 ms | 1.34x slower |
| Star | 50,000,000 | 964.23 ms | 1,081.88 ms | 1.12x slower |
| Path | 50,000,000 | 267.79 ms | 906.47 ms | 3.39x slower |

The new implementation is strongest on high-coreness and high-contention workloads. ParK remains
preferable for very sparse, low-coreness graphs where the additional sampling, bucketing, and
compaction state cannot be amortized.

## Reproducing the benchmarks

```bash
OMP_NUM_THREADS=15 .venv/bin/python \
    examples/benchmark_parallel_core_decomposition.py \
    --case large-all \
    --large-edges 100000000 \
    --threads 15 \
    --repeats 5
```

The benchmark also supports `large-sparse-er`, `large-star`, and `large-path`.

## Scope and limitations

This PR implements the paper-inspired online peeling path. It does not yet implement the reference
artifact's offline peeling path or its online/offline selection strategy.

These benchmarks are Icebug implementation benchmarks on synthetic graphs.
