### PR TITLE
ci: build linux gcc in a manylinux_2_28 container for glibc compat

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -240,6 +240,22 @@ jobs:
             cxx: g++
             artifact_name: icebug-linux-arm64
             archive: icebug-linux-arm64.tar.gz
+          - os: linux
+            arch: x86_64
+            compiler: llvm-20
+            runner: ubuntu-latest
+            cc: clang-20
+            cxx: clang++-20
+            artifact_name: icebug-linux-x86_64-perf
+            archive: icebug-linux-x86_64-perf.tar.gz
+          - os: linux
+            arch: arm64
+            compiler: llvm-20
+            runner: ubuntu-24.04-arm
+            cc: clang-20
+            cxx: clang++-20
+            artifact_name: icebug-linux-arm64-perf
+            archive: icebug-linux-arm64-perf.tar.gz
           - os: macos
             arch: arm64
             compiler: llvm-20
@@ -264,8 +280,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Install prerequisites (Linux)
-        if: matrix.os == 'linux'
+      - name: Install prerequisites (Linux, manylinux gcc-13)
+        if: matrix.os == 'linux' && matrix.compiler == 'gcc-13'
         run: |
           dnf install -y 'dnf-command(config-manager)'
           dnf config-manager --set-enabled powertools
@@ -276,11 +292,21 @@ jobs:
           dnf install -y cmake git wget unzip gcc-toolset-13
 
       - name: Enable gcc-13 toolset (Linux container)
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && matrix.compiler == 'gcc-13'
         run: |
           source /opt/rh/gcc-toolset-13/enable
           echo "/opt/rh/gcc-toolset-13/root/usr/bin" >> "$GITHUB_PATH"
           echo "LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
+      - name: Install prerequisites (Linux, llvm-20 perf)
+        if: matrix.os == 'linux' && matrix.compiler == 'llvm-20'
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
+          echo "deb http://apt.llvm.org/noble llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm20.list
+          wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
+          sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
+          sudo apt-get update
+          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev
 
       - name: Install prerequisites (macOS)
         if: matrix.os == 'macos'

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -24,9 +24,9 @@ env:
 
 jobs:
   build:
-    name: "${{ matrix.os }} (${{ matrix.compiler }})"
+    name: "${{ matrix.os }} (${{ matrix.arch }}, ${{ matrix.compiler }})"
     runs-on: ${{ matrix.runner }}
-    # Only the gcc-13 build runs in the manylinux_2_28 container (glibc 2.28
+    # The gcc-13 builds run in manylinux_2_28 containers (glibc 2.28
     # compatible release binaries); macos/windows/llvm-20 run on their runners.
     container: ${{ matrix.container }}
     strategy:
@@ -34,22 +34,33 @@ jobs:
       matrix:
         include:
           - os: linux
+            arch: x86_64
             compiler: gcc-13
             runner: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64
             cc: gcc
             cxx: g++
           - os: linux
+            arch: arm64
+            compiler: gcc-13
+            runner: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            cc: gcc
+            cxx: g++
+          - os: linux
+            arch: x86_64
             compiler: llvm-20
             runner: ubuntu-latest
             cc: clang-20
             cxx: clang++-20
           - os: macos
+            arch: arm64
             compiler: llvm-20
             runner: macos-15
             cc: /opt/homebrew/opt/llvm@20/bin/clang
             cxx: /opt/homebrew/opt/llvm@20/bin/clang++
           - os: windows
+            arch: amd64
             compiler: msvc
             runner: windows-2022
             cc: cl
@@ -204,24 +215,29 @@ jobs:
     # Skip on PRs — release artifacts are only needed on main and manual runs.
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runner }}
+    # Linux release binaries are built in manylinux_2_28 containers so they are
+    # usable on glibc >= 2.28; macOS/Windows build on their own runners.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: linux
             arch: x86_64
-            compiler: llvm-20
+            compiler: gcc-13
             runner: ubuntu-latest
-            cc: clang-20
-            cxx: clang++-20
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            cc: gcc
+            cxx: g++
             artifact_name: icebug-linux-x86_64
             archive: icebug-linux-x86_64.tar.gz
           - os: linux
             arch: arm64
-            compiler: llvm-20
+            compiler: gcc-13
             runner: ubuntu-24.04-arm
-            cc: clang-20
-            cxx: clang++-20
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            cc: gcc
+            cxx: g++
             artifact_name: icebug-linux-arm64
             archive: icebug-linux-arm64.tar.gz
           - os: macos
@@ -251,12 +267,20 @@ jobs:
       - name: Install prerequisites (Linux)
         if: matrix.os == 'linux'
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
-          echo "deb http://apt.llvm.org/noble llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm20.list
-          wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
-          sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
-          sudo apt-get update
-          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled powertools
+          dnf install -y epel-release
+          # Arrow RPMs have a GPG key mismatch, so we use --nogpgcheck.
+          dnf install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe)/apache-arrow-release-latest.rpm
+          dnf install -y --nogpgcheck --enablerepo=epel arrow-devel arrow-compute-devel ninja-build ccache
+          dnf install -y cmake git wget unzip gcc-toolset-13
+
+      - name: Enable gcc-13 toolset (Linux container)
+        if: matrix.os == 'linux'
+        run: |
+          source /opt/rh/gcc-toolset-13/enable
+          echo "/opt/rh/gcc-toolset-13/root/usr/bin" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 
       - name: Install prerequisites (macOS)
         if: matrix.os == 'macos'
@@ -318,7 +342,7 @@ jobs:
         run: |
           cmake -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/dist \
+            -DCMAKE_INSTALL_PREFIX=$PWD/dist \
             -DNETWORKIT_MONOLITH=ON \
             -DNETWORKIT_CXX_STANDARD=${{ env.CXX_STANDARD }} \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -26,15 +26,19 @@ jobs:
   build:
     name: "${{ matrix.os }} (${{ matrix.compiler }})"
     runs-on: ${{ matrix.runner }}
+    # Only the gcc-13 build runs in the manylinux_2_28 container (glibc 2.28
+    # compatible release binaries); macos/windows/llvm-20 run on their runners.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: linux
-            compiler: gcc-14
+            compiler: gcc-13
             runner: ubuntu-latest
-            cc: gcc-14
-            cxx: g++-14
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            cc: gcc
+            cxx: g++
           - os: linux
             compiler: llvm-20
             runner: ubuntu-latest
@@ -91,12 +95,15 @@ jobs:
           sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev=25.0.0-1
 
       - name: Install prerequisites (Linux)
-        if: matrix.os == 'linux' && matrix.compiler == 'gcc-14'
+        if: matrix.os == 'linux' && matrix.compiler == 'gcc-13'
         run: |
-          wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
-          sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
-          sudo apt-get update
-          sudo apt-get install -y g++-14 ninja-build libarrow-dev=25.0.0-1
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled powertools
+          dnf install -y epel-release
+          # Arrow RPMs have a GPG key mismatch, so we use --nogpgcheck.
+          dnf install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe)/apache-arrow-release-latest.rpm
+          dnf install -y --nogpgcheck --enablerepo=epel arrow-devel arrow-compute-devel ninja-build ccache
+          dnf install -y cmake git wget unzip gcc-toolset-13
 
       - name: Install prerequisites (macOS)
         if: matrix.os == 'macos'
@@ -149,7 +156,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Run clang-format check (Linux)
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && matrix.compiler != 'gcc-13'
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
           echo "deb http://apt.llvm.org/noble llvm-toolchain-noble-18 main" | sudo tee /etc/apt/sources.list.d/llvm18.list
@@ -170,15 +177,17 @@ jobs:
 
       - name: Prepare environment and run checks (Linux/macOS)
         if: matrix.os != 'windows'
-        run: ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+        run: |
+          if [ "${{ matrix.compiler }}" = "gcc-13" ]; then source /opt/rh/gcc-toolset-13/enable; fi
+          ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
         shell: bash
 
       - name: Setup uv (Linux)
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && matrix.compiler != 'gcc-13'
         uses: astral-sh/setup-uv@v5
 
       - name: Run pytest (Linux)
-        if: matrix.os == 'linux'
+        if: matrix.os == 'linux' && matrix.compiler != 'gcc-13'
         run: |
           uv sync --extra pytest
           uv pip install -e ".[test]"

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -179,7 +179,7 @@ jobs:
         if: matrix.os != 'windows'
         run: |
           if [ "${{ matrix.compiler }}" = "gcc-13" ]; then source /opt/rh/gcc-toolset-13/enable; fi
-          ${{ github.workspace }}/.github/workflows/scripts/cpp_only.sh
+          .github/workflows/scripts/cpp_only.sh
         shell: bash
 
       - name: Setup uv (Linux)


### PR DESCRIPTION
## Summary

The `gcc-14` Linux build in `ci-matrix.yml` ran on the `ubuntu-24.04` host runner (glibc 2.39), which made release binaries unusable on older glibc systems. This runs that build inside a `quay.io/pypa/manylinux_2_28_x86_64` container so it targets glibc ≥ 2.28, mirroring `ladybug-extension/.github/workflows/ci.yml`.

## Changes (build job matrix, Linux gcc entry only)

- `gcc-14` → `gcc-13`, run in `container: quay.io/pypa/manylinux_2_28_x86_64` (`container` set via the matrix; empty for macos/windows → no container)
- Compiler activated by sourcing `gcc-toolset-13`
- **apt → dnf**: powertools enabled, EPEL for `ninja-build`/`ccache`, Arrow from the `${arrow}/centos/8/apache-arrow-release-latest.rpm` repo with `--nogpgcheck` (known GPG key mismatch)

## Container entry is build-only

- clang-format check, `setup-uv`, and `pytest` are skipped for the `gcc-13` container entry (they rely on `apt`/`sudo` and are runner-specific); the container entry exists to produce glibc-compatible binaries.

## Intentionally untouched

- `llvm-20` linux build stays on ubuntu — a performance/validation build targeting a newer toolchain
- macOS and windows entries
- `release-build` job (skipped on PRs) keeps using llvm-20 on ubuntu