### PR TITLE
Implement InducedSubgraphView over GraphLike; make CoarsenedGraphView one

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -103,7 +103,16 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
           sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
           sudo apt-get update
-          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev=25.0.0-1
+          # Arrow's apt repo drops old minors as soon as a new one ships, so an exact pin
+          # (libarrow-dev=25.0.0-1) breaks on every upstream release. Pin the whole 25
+          # series instead: >= 25.0.0, < 26. The pytest step keys on the SONAME
+          # libarrow.so.2500, which is stable across the 25.x series.
+          sudo tee /etc/apt/preferences.d/apache-arrow > /dev/null <<'EOF'
+          Package: libarrow* apache-arrow*
+          Pin: version 25.*
+          Pin-Priority: 1001
+          EOF
+          sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev
 
       - name: Install prerequisites (Linux)
         if: matrix.os == 'linux' && matrix.compiler == 'gcc-13'
@@ -143,7 +152,7 @@ jobs:
         if: matrix.os == 'windows'
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'b322364f06308bdd24823f9d8f03fe0cc86fd46f'
+          vcpkgGitCommitId: '9e593bb18ea69cc5095e012465dcd675a822ed0d'
 
       - name: Authenticate vcpkg NuGet (Windows)
         if: matrix.os == 'windows'
@@ -306,6 +315,12 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb
           sudo apt-get install -y ./apache-arrow-apt-source-latest-noble.deb
           sudo apt-get update
+          # Same 25-series pin as the PR build: >= 25.0.0, < 26.
+          sudo tee /etc/apt/preferences.d/apache-arrow > /dev/null <<'EOF'
+          Package: libarrow* apache-arrow*
+          Pin: version 25.*
+          Pin-Priority: 1001
+          EOF
           sudo apt-get install -y clang-20 libomp-20-dev ninja-build libarrow-dev
 
       - name: Install prerequisites (macOS)
@@ -332,7 +347,7 @@ jobs:
         if: matrix.os == 'windows'
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'b322364f06308bdd24823f9d8f03fe0cc86fd46f'
+          vcpkgGitCommitId: '9e593bb18ea69cc5095e012465dcd675a822ed0d'
 
       - name: Authenticate vcpkg NuGet (Windows)
         if: matrix.os == 'windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'b322364f06308bdd24823f9d8f03fe0cc86fd46f'
+          vcpkgGitCommitId: '9e593bb18ea69cc5095e012465dcd675a822ed0d'
           runVcpkgInstall: true
         env:
           VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
@@ -371,7 +371,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'b322364f06308bdd24823f9d8f03fe0cc86fd46f'
+          vcpkgGitCommitId: '9e593bb18ea69cc5095e012465dcd675a822ed0d'
           runVcpkgInstall: true
         env:
           VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'

--- a/docs/ICEBUG_DESIGN.md
+++ b/docs/ICEBUG_DESIGN.md
@@ -217,9 +217,11 @@ networkit/
 
 `ReferenceGraph` is the `Graph` name algorithms see: a non-owning variant handle over the two
 concrete graphs plus the two view instantiations (`InducedSubgraphView<GraphW>` and
-`InducedSubgraphView<GraphR>`). Binding a view is implicit — `CoreDecomposition(view)` compiles
-unchanged — while binding a concrete graph stays explicit so no temporary can be materialized by
-accident.
+`InducedSubgraphView<GraphR>`). Every arm derives `SelfHandled`, so conversion yields the handle
+embedded inside the graph object itself — one address per object, stable across statements, which
+is what makes "construct an algorithm, then run it" sound. `CoreDecomposition(view)` therefore
+compiles unchanged *and* binds to storage the view owns; the direct converting constructors are
+`explicit` on all four arms so no route can silently materialize a temporary.
 
 Two consequences worth remembering when touching either side:
 

--- a/docs/ICEBUG_DESIGN.md
+++ b/docs/ICEBUG_DESIGN.md
@@ -205,12 +205,31 @@ include/networkit/community/
 ```
 networkit/
 ├── graph.pxd          # Cython declarations
-├── graph.pyx          # Python bindings for Graph/GraphW
+├── graph.pyx          # Python bindings for Graph/GraphW/InducedSubgraphView
 ├── community.pyx      # ParallelLeidenView bindings
 └── test/
     ├── test_parallel_leiden.py     # Leiden tests
-    └── test_arrow_pagerank.py      # Arrow integration tests
+    ├── test_arrow_pagerank.py      # Arrow integration tests
+    └── test_induced_subgraph_view.py  # InducedSubgraphView bindings
 ```
+
+### Views and the Type-Erased Handle
+
+`ReferenceGraph` is the `Graph` name algorithms see: a non-owning variant handle over the two
+concrete graphs plus the two view instantiations (`InducedSubgraphView<GraphW>` and
+`InducedSubgraphView<GraphR>`). Binding a view is implicit — `CoreDecomposition(view)` compiles
+unchanged — while binding a concrete graph stays explicit so no temporary can be materialized by
+accident.
+
+Two consequences worth remembering when touching either side:
+
+- The view's neighbor iterators are self-contained (they own their borrowed base range through a
+  shared handle), because the erased ranges copy cursors out of temporaries. The view arms travel
+  through `AnyNeighborCursor`, a small virtual cursor, since the handle header cannot name the
+  view's iterator types without a cycle.
+- The views carry no edge ids and no attribute maps; the corresponding handle calls throw rather
+	than silently degrade. Python mirrors this: attribute attachment on a view-backed graph raises,
+	and mutation goes through `_mutable()`, which rejects view seats.
 
 ## Python API
 

--- a/docs/ICEBUG_DESIGN.md
+++ b/docs/ICEBUG_DESIGN.md
@@ -181,7 +181,8 @@ include/networkit/graph/
 ├── GraphR.hpp         # CSR-based immutable implementation
 ├── GraphR.cpp         # CSR implementation
 ├── GraphW.hpp         # Mutable graph with vector storage
-└── GraphW.cpp         # Vector-based implementation
+├── GraphW.cpp         # Vector-based implementation
+└── InducedSubgraphView.hpp  # Zero-copy induced subgraph over any GraphLike base
 ```
 
 ### Coarsening Infrastructure

--- a/include/networkit/coarsening/CoarsenedGraphView.hpp
+++ b/include/networkit/coarsening/CoarsenedGraphView.hpp
@@ -7,21 +7,39 @@
 #ifndef NETWORKIT_COARSENING_COARSENED_GRAPH_VIEW_HPP_
 #define NETWORKIT_COARSENING_COARSENED_GRAPH_VIEW_HPP_
 
+#include <utility>
 #include <vector>
+
 #include <networkit/Globals.hpp>
 #include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
+#include <networkit/graph/GraphIterationOps.hpp>
 #include <networkit/structures/Partition.hpp>
 
 namespace NetworKit {
 
 /**
  * @ingroup coarsening
- * Memory-efficient view of a coarsened graph that avoids creating new graph structures.
- * This class provides a graph-like interface over the original CSR graph by maintaining
- * only the node mapping information, computing edges on-demand.
+ * Memory-efficient zero-copy view of a coarsened graph that avoids creating new graph structures.
+ * This class provides a GraphLike interface over the original CSR graph by maintaining only the
+ * node mapping information, computing edges on-demand.
+ *
+ * The view implements the GraphLike concept: it declares the primitives from
+ * <networkit/graph/GraphConcepts.hpp> and inherits the whole @c for* family, lookups and weight
+ * aggregates as free operations, re-exposed as members. Supernode ids are dense in @c [0,
+ * numberOfNodes()), so iteration never consults hasNode().
+ *
+ * Neighborhoods are aggregated on demand: every call to outNeighbors() walks the adjacency of the
+ * member nodes and merges weights into one entry per adjacent supernode. The returned range is an
+ * owning vector rather than a borrowed view -- there is no stored coarsened adjacency to point at.
+ * Entries with non-positive aggregated weight are dropped.
  */
 class CoarsenedGraphView {
 public:
+    /// Node ids are dense: the constructor compacts the partition, so every id in
+    /// [0, numberOfNodes()) exists.
+    static constexpr bool alwaysContiguousNodeIds = true;
+
     /**
      * Construct a coarsened graph view from the original graph and partition.
      * @param originalGraph The original CSR graph
@@ -38,6 +56,8 @@ public:
      */
     CoarsenedGraphView(const CoarsenedGraphView &baseView, const Partition &partition);
 
+    /* GRAPHLIKE PRIMITIVES */
+
     /**
      * Get the number of nodes (supernodes) in the coarsened view
      */
@@ -45,76 +65,188 @@ public:
 
     /**
      * Get the number of edges in the coarsened view
+     *
+     * Aggregates every supernode neighborhood once; O(sum of the members' degrees).
      */
     count numberOfEdges() const;
 
-    /**
-     * Check if a supernode exists
-     */
+    /// Node ids are dense, so the upper node id bound is the supernode count.
+    index upperNodeIdBound() const { return numSupernodes; }
+
+    /// True when @a supernode is in [0, numberOfNodes()).
     bool hasNode(node supernode) const { return supernode < numSupernodes; }
+
+    bool isEmpty() const { return numSupernodes == 0; }
 
     /**
      * Get the degree of a supernode (number of adjacent supernodes)
      */
     count degree(node supernode) const;
 
+    /// The view is undirected regardless of the original graph.
+    bool isDirected() const { return false; }
+
+    /// The view is always weighted: aggregated edge weights are carried on the neighborhoods.
+    bool isWeighted() const { return true; }
+
+    /**
+     * The number of supernodes carrying a positive-weight self-loop in this view.
+     */
+    count numberOfSelfLoops() const;
+
+    /**
+     * The aggregated out-neighbors of @a supernode: one entry per adjacent supernode, carrying the
+     * summed edge weight. The range is an owning vector recomputed on each call; entries with
+     * non-positive aggregated weight are dropped.
+     */
+    template <bool Weighted>
+    std::vector<std::pair<node, edgeweight>> outNeighbors(node supernode) const {
+        if (!hasNode(supernode))
+            return {};
+        return computeNeighbors(supernode);
+    }
+
+    /// The view is undirected: the in-neighbors are the out-neighbors.
+    template <bool Weighted>
+    std::vector<std::pair<node, edgeweight>> inNeighbors(node supernode) const {
+        return outNeighbors<Weighted>(supernode);
+    }
+
+    auto neighborRange(node u) const { return outNeighbors<false>(u); }
+    auto weightNeighborRange(node u) const { return outNeighbors<true>(u); }
+    auto inNeighborRange(node u) const { return inNeighbors<false>(u); }
+    auto weightInNeighborRange(node u) const { return inNeighbors<true>(u); }
+
+    /* ITERATION, LOOKUPS, AND WEIGHT AGGREGATES (free operations) */
+
+    /*
+     * Thin forwarders to the free operations in GraphIterationOps, which are implemented once in
+     * terms of the GraphLike primitives. A call goes straight to the compile-time-selected body,
+     * so there is no runtime dispatch and no base class to inherit.
+     */
+
+    template <typename = void>
+    bool hasContiguousNodeIds() const {
+        return NetworKit::hasContiguousNodeIds(*this);
+    }
+
+    template <typename L>
+    void forNodes(L handle) const {
+        GraphIterationOps::forNodes(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForNodes(L handle) const {
+        GraphIterationOps::parallelForNodes(*this, handle);
+    }
+
+    template <typename C, typename L>
+    void forNodesWhile(C condition, L handle) const {
+        GraphIterationOps::forNodesWhile(*this, condition, handle);
+    }
+
+    template <typename L>
+    void forNodesInRandomOrder(L handle) const {
+        GraphIterationOps::forNodesInRandomOrder(*this, handle);
+    }
+
+    template <typename L>
+    void balancedParallelForNodes(L handle) const {
+        GraphIterationOps::balancedParallelForNodes(*this, handle);
+    }
+
+    template <typename L>
+    void forNodePairs(L handle) const {
+        GraphIterationOps::forNodePairs(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForNodePairs(L handle) const {
+        GraphIterationOps::parallelForNodePairs(*this, handle);
+    }
+
+    template <typename L>
+    void forEdges(L handle) const {
+        GraphIterationOps::forEdges(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForEdges(L handle) const {
+        GraphIterationOps::parallelForEdges(*this, handle);
+    }
+
+    template <typename L>
+    void forNeighborsOf(node u, L handle) const {
+        GraphIterationOps::forNeighborsOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forEdgesOf(node u, L handle) const {
+        GraphIterationOps::forEdgesOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forInNeighborsOf(node u, L handle) const {
+        GraphIterationOps::forInNeighborsOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forInEdgesOf(node u, L handle) const {
+        GraphIterationOps::forInEdgesOf(*this, u, handle);
+    }
+
+    template <typename L>
+    double parallelSumForNodes(L handle) const {
+        return GraphIterationOps::parallelSumForNodes(*this, handle);
+    }
+
+    template <typename L>
+    double parallelSumForEdges(L handle) const {
+        return GraphIterationOps::parallelSumForEdges(*this, handle);
+    }
+
     /**
      * Get the weighted degree of a supernode
      * @param countSelfLoopsTwice If true, count self-loops twice (for undirected graphs)
      */
-    edgeweight weightedDegree(node supernode, bool countSelfLoopsTwice = false) const;
-
-    /**
-     * Check if there's an edge between two supernodes
-     */
-    bool hasEdge(node u, node v) const;
-
-    /**
-     * Get the weight of an edge between two supernodes
-     */
-    edgeweight weight(node u, node v) const;
-
-    /**
-     * Iterate over neighbors of a supernode
-     * @param supernode The supernode to iterate neighbors for
-     * @param handle Function to call for each neighbor: void(node neighbor, edgeweight weight)
-     */
-    template <typename Lambda>
-    void forNeighborsOf(node supernode, Lambda handle) const {
-        if (!hasNode(supernode))
-            return;
-
-        auto neighbors = getNeighbors(supernode);
-        for (const auto &entry : neighbors) {
-            handle(entry.first, entry.second);
-        }
+    template <typename = void>
+    edgeweight weightedDegree(node u, bool countSelfLoopsTwice = false) const {
+        return GraphIterationOps::weightedDegree(*this, u, countSelfLoopsTwice);
     }
 
-    /**
-     * Iterate over all edges in the coarsened view
-     * @param handle Function to call for each edge: void(node u, node v, edgeweight weight)
-     */
-    template <typename Lambda>
-    void forEdges(Lambda handle) const {
-        for (node u = 0; u < numberOfNodes(); ++u) {
-            forNeighborsOf(u, [&](node v, edgeweight w) {
-                if (u <= v) { // Only report each edge once for undirected graphs
-                    handle(u, v, w);
-                }
-            });
-        }
+    template <typename = void>
+    edgeweight weightedDegreeIn(node u, bool countSelfLoopsTwice = false) const {
+        return GraphIterationOps::weightedDegreeIn(*this, u, countSelfLoopsTwice);
     }
 
-    /**
-     * Parallel iteration over nodes
-     */
-    template <typename Lambda>
-    void parallelForNodes(Lambda handle) const {
-#pragma omp parallel for
-        for (omp_index u = 0; u < static_cast<omp_index>(numberOfNodes()); ++u) {
-            handle(static_cast<node>(u));
-        }
+    template <typename = void>
+    edgeweight totalEdgeWeight() const {
+        return GraphIterationOps::totalEdgeWeight(*this);
     }
+
+    /// O(1): the undirected degree.
+    count degreeOut(node u) const { return degree(u); }
+
+    /// O(1): the undirected degree.
+    count degreeIn(node u) const { return degree(u); }
+
+    /// O(deg(u)): linear scan over the aggregated neighborhood.
+    template <typename = void>
+    bool hasEdge(node u, node v) const {
+        if (!hasNode(u) || !hasNode(v))
+            return false;
+        return GraphIterationOps::hasEdge(*this, u, v);
+    }
+
+    /// O(deg(u)); nullWeight when the edge is absent.
+    template <typename = void>
+    edgeweight weight(node u, node v) const {
+        if (!hasNode(u) || !hasNode(v))
+            return nullWeight;
+        return GraphIterationOps::weight(*this, u, v);
+    }
+
+    /* VIEW-SPECIFIC ACCESSORS */
 
     /**
      * Get the mapping from original nodes to supernodes
@@ -126,21 +258,6 @@ public:
      */
     const std::vector<node> &getOriginalNodes(node supernode) const;
 
-    /**
-     * Check if the graph is weighted (always true for coarsened views)
-     */
-    bool isWeighted() const { return true; }
-
-    /**
-     * Check if the graph is directed (always false for current implementation)
-     */
-    bool isDirected() const { return false; }
-
-    /**
-     * Get upper bound for node IDs
-     */
-    node upperNodeIdBound() const { return numSupernodes; }
-
 private:
     const Graph &originalGraph;
     std::vector<node> nodeMapping;                      // original_node -> supernode
@@ -148,17 +265,16 @@ private:
     count numSupernodes;
 
     /**
-     * Get neighbors of a supernode (compute on demand, no caching)
-     */
-    std::vector<std::pair<node, edgeweight>> getNeighbors(node supernode) const {
-        return computeNeighbors(supernode);
-    }
-
-    /**
-     * Compute neighbors of a supernode
+     * Compute the aggregated neighbors of a supernode (on demand, no caching)
      */
     std::vector<std::pair<node, edgeweight>> computeNeighbors(node supernode) const;
 };
+
+static_assert(GraphLike<CoarsenedGraphView>,
+              "the coarsened view must be usable wherever a graph type is");
+static_assert(!IndexedGraph<CoarsenedGraphView>, "aggregated edges carry no edge ids");
+static_assert(!MutableGraph<CoarsenedGraphView>, "a view cannot be mutated");
+static_assert(CoarsenedGraphView::alwaysContiguousNodeIds);
 
 } /* namespace NetworKit */
 

--- a/include/networkit/graph/GraphIterationOps.hpp
+++ b/include/networkit/graph/GraphIterationOps.hpp
@@ -252,17 +252,34 @@ inline count degreeIn(const G &g, node u) {
 /// O(log d) on sorted neighborhoods, O(d) otherwise.
 template <typename G>
 inline bool hasEdge(const G &g, node u, node v) {
-    if (hasSortedNeighborhoods(g))
-        return std::ranges::binary_search(g.template outNeighbors<false>(u), v);
+    /*
+     * Bisection needs the unweighted payload to order against a bare node. A neighborhood may
+     * instead carry (node, weight) pairs -- e.g. a view that aggregates weights on the fly --
+     * which sorts by target just fine but does not compare with v, so it falls back to the scan.
+     */
+    constexpr bool bisectable = requires(const G &gg, node uu, node vv) {
+        std::ranges::binary_search(gg.template outNeighbors<false>(uu), vv);
+    };
+    if constexpr (bisectable) {
+        if (hasSortedNeighborhoods(g))
+            return std::ranges::binary_search(g.template outNeighbors<false>(u), v);
+    }
     for (auto nb : g.template outNeighbors<false>(u))
         if (neighborTarget(nb) == v)
             return true;
     return false;
 }
 
-/// O(d); nullWeight when the edge is absent.
+/// O(d); nullWeight when the edge is absent. On an unweighted graph an existing edge weighs
+/// defaultEdgeWeight, mirroring the concrete graphs' own weight().
 template <typename G>
 inline edgeweight weight(const G &g, node u, node v) {
+    if (!g.isWeighted()) {
+        for (auto nb : g.template outNeighbors<false>(u))
+            if (neighborTarget(nb) == v)
+                return defaultEdgeWeight;
+        return nullWeight;
+    }
     for (auto nb : g.template outNeighbors<true>(u))
         if (neighborTarget(nb) == v)
             return neighborWeight(nb);

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -216,12 +216,12 @@ private:
                 return copy;
             }
 
-            friend bool operator==(const iterator &a, const iterator &b) noexcept {
-                if (a.atEnd_ || b.atEnd_)
-                    return a.atEnd_ && b.atEnd_;
-                if (a.range_ != b.range_)
+            bool operator==(const iterator &other) const noexcept {
+                if (atEnd_ || other.atEnd_)
+                    return atEnd_ && other.atEnd_;
+                if (range_ != other.range_)
                     return false;
-                return a.range_->scanSubset_ ? a.pos_ == b.pos_ : a.baseIt_ == b.baseIt_;
+                return range_->scanSubset_ ? pos_ == other.pos_ : baseIt_ == other.baseIt_;
             }
 
         private:

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -13,6 +13,7 @@
 #include <initializer_list>
 #include <ranges>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -20,8 +21,18 @@
 #include <networkit/graph/GraphConcepts.hpp>
 #include <networkit/graph/GraphIterationOps.hpp>
 #include <networkit/graph/GraphW.hpp>
+#include <networkit/graph/ReferenceGraph.hpp>
 
 namespace NetworKit {
+
+namespace InducedSubgraphViewDetail {
+/**
+ * Stand-in base for bases that are not handle arms (a view of a view, say): there is no embedded
+ * handle to carry, so the base contributes nothing. Keeping it empty is what lets the real base,
+ * SelfHandled, stay true to its documented requirement that Derived be a variant alternative.
+ */
+struct NoEmbeddedHandle {};
+} // namespace InducedSubgraphViewDetail
 
 /**
  * @ingroup graph
@@ -45,7 +56,10 @@ namespace NetworKit {
  * like ranges borrowed from a GraphW are invalidated by mutation.
  */
 template <typename BaseGraph>
-class InducedSubgraphView {
+class InducedSubgraphView : public std::conditional_t<std::is_same_v<BaseGraph, GraphW>
+                                                          || std::is_same_v<BaseGraph, GraphR>,
+                                                      SelfHandled<InducedSubgraphView<BaseGraph>>,
+                                                      InducedSubgraphViewDetail::NoEmbeddedHandle> {
     static_assert(GraphLike<BaseGraph>, "the base graph of an induced view must be GraphLike");
 
 public:

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -1,0 +1,489 @@
+/*
+ * InducedSubgraphView.hpp
+ *
+ *  A zero-copy induced subgraph over any GraphLike base graph.
+ */
+
+#ifndef NETWORKIT_GRAPH_INDUCED_SUBGRAPH_VIEW_HPP_
+#define NETWORKIT_GRAPH_INDUCED_SUBGRAPH_VIEW_HPP_
+
+#include <algorithm>
+#include <cassert>
+#include <initializer_list>
+#include <ranges>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <networkit/Globals.hpp>
+#include <networkit/graph/GraphConcepts.hpp>
+#include <networkit/graph/GraphIterationOps.hpp>
+#include <networkit/graph/GraphW.hpp>
+
+namespace NetworKit {
+
+/**
+ * @ingroup graph
+ * InducedSubgraphView - a zero-copy induced subgraph of a base graph.
+ *
+ * The view spans a subset of the base graph's nodes and, implicitly, every base edge whose two
+ * endpoints are in the subset. It works over any type satisfying the GraphLike concept --
+ * GraphR, GraphW, CoarsenedGraphView, another InducedSubgraphView -- and keeps the base graph's
+ * node ids, so results computed on the view map straight back onto the base graph.
+ *
+ * Membership is edited in batches (@c addNodes / @c removeNodes). The induced degrees, the edge
+ * count and the self-loop count are maintained incrementally while the batch is applied, which
+ * keeps every GraphLike primitive O(1). Neighborhoods are never materialized: each range filters
+ * the base adjacency on the fly, so the view's memory footprint is one presence flag and one or
+ * two degree counters per base node.
+ *
+ * The base graph must outlive the view and must not be modified while the view exists; ranges
+ * borrowed from the view are additionally invalidated by any addNodes()/removeNodes() call, just
+ * like ranges borrowed from a GraphW are invalidated by mutation.
+ */
+template <typename BaseGraph>
+class InducedSubgraphView {
+    static_assert(GraphLike<BaseGraph>, "the base graph of an induced view must be GraphLike");
+
+public:
+    /**
+     * An empty view on @a base.
+     * @param base The graph the view spans. Must outlive the view.
+     */
+    explicit InducedSubgraphView(const BaseGraph &base)
+        : base_(&base), directed_(base.isDirected()) {
+        const index z = base.upperNodeIdBound();
+        exists_.assign(z, 0);
+        outDegree_.assign(z, 0);
+        if (directed_)
+            inDegree_.assign(z, 0);
+    }
+
+    /**
+     * A view on @a base spanning @a subset. Node ids must exist in the base graph; duplicates are
+     * ignored.
+     */
+    template <typename NodeRange>
+    InducedSubgraphView(const BaseGraph &base, const NodeRange &subset)
+        : InducedSubgraphView(base) {
+        addNodes(subset);
+    }
+
+    /// The initializer-list flavor of the subset constructor above.
+    InducedSubgraphView(const BaseGraph &base, std::initializer_list<node> subset)
+        : InducedSubgraphView(base) {
+        addNodes(subset);
+    }
+
+    InducedSubgraphView(const InducedSubgraphView &) = default;
+    InducedSubgraphView(InducedSubgraphView &&) noexcept = default;
+    InducedSubgraphView &operator=(const InducedSubgraphView &) = default;
+    InducedSubgraphView &operator=(InducedSubgraphView &&) noexcept = default;
+
+    /* MEMBERSHIP EDITS */
+
+    /// Adds the single node @a u to the subset. Throws if @a u is not in the base graph.
+    void addNode(node u) { addNodes(std::initializer_list<node>{u}); }
+
+    /// Adds @a nodes to the subset. Unknown ids throw; already present ids are ignored.
+    void addNodes(std::initializer_list<node> nodes) { addNodesImpl(nodes); }
+
+    /// Adds every node of @a nodes to the subset. Unknown ids throw; already present ids are
+    /// ignored. The order of @a nodes does not matter.
+    template <typename NodeRange>
+    void addNodes(const NodeRange &nodes) {
+        addNodesImpl(nodes);
+    }
+
+    /// Removes the single node @a u from the subset, if present.
+    void removeNode(node u) { removeNodes(std::initializer_list<node>{u}); }
+
+    /// Removes @a nodes from the subset. Absent ids are ignored.
+    void removeNodes(std::initializer_list<node> nodes) { removeNodesImpl(nodes); }
+
+    /// Removes every node of @a nodes from the subset. Absent ids are ignored.
+    template <typename NodeRange>
+    void removeNodes(const NodeRange &nodes) {
+        removeNodesImpl(nodes);
+    }
+
+    /* GRAPHLIKE PRIMITIVES */
+
+    count numberOfNodes() const noexcept { return n_; }
+
+    /// The induced edge count; maintained incrementally, O(1).
+    count numberOfEdges() const noexcept { return m_; }
+
+    /// The base graph's upper node id bound: the view keeps the base ids.
+    index upperNodeIdBound() const noexcept { return exists_.size(); }
+
+    bool hasNode(node u) const noexcept { return u < exists_.size() && exists_[u]; }
+
+    /// The induced out-degree of @a u; O(1). Requires hasNode(u).
+    count degree(node u) const {
+        assert(hasNode(u));
+        return outDegree_[u];
+    }
+
+    bool isEmpty() const noexcept { return n_ == 0; }
+
+    bool isDirected() const noexcept { return directed_; }
+
+    /// Mirrors the base graph: the view carries whatever weights the base carries.
+    bool isWeighted() const { return base_->isWeighted(); }
+
+    /// The induced self-loop count; maintained incrementally, O(1).
+    count numberOfSelfLoops() const noexcept { return selfLoops_; }
+
+    /**
+     * The out-neighbors of @a u inside the view: the base neighborhood filtered by membership.
+     * The range borrows the base graph's storage and this view's flags, and is invalidated by any
+     * membership edit. @tparam Weighted selects the (node, weight) payload; an unweighted base
+     * has no weight array, so only request it when isWeighted() holds.
+     */
+    template <bool Weighted>
+    auto outNeighbors(node u) const {
+        assert(hasNode(u));
+        return std::ranges::owning_view(base_->template outNeighbors<Weighted>(u))
+               | std::views::filter([this](const auto &nb) { return hasNode(neighborTarget(nb)); });
+    }
+
+    /// The in-neighbors of @a u inside the view. On an undirected base these are the out-neighbors.
+    template <bool Weighted>
+    auto inNeighbors(node u) const {
+        assert(hasNode(u));
+        return std::ranges::owning_view(base_->template inNeighbors<Weighted>(u))
+               | std::views::filter([this](const auto &nb) { return hasNode(neighborTarget(nb)); });
+    }
+
+    auto neighborRange(node u) const { return outNeighbors<false>(u); }
+    auto weightNeighborRange(node u) const { return outNeighbors<true>(u); }
+    auto inNeighborRange(node u) const { return inNeighbors<false>(u); }
+    auto weightInNeighborRange(node u) const { return inNeighbors<true>(u); }
+
+    /// Honest at runtime: filtering preserves the base neighborhoods' order.
+    bool hasSortedNeighborhoods() const {
+        if constexpr (requires { base_->hasSortedNeighborhoods(); })
+            return base_->hasSortedNeighborhoods();
+        else
+            return false;
+    }
+
+    /* ITERATION, LOOKUPS, AND WEIGHT AGGREGATES (free operations) */
+
+    /*
+     * Thin forwarders to the free operations in GraphIterationOps, which are implemented once in
+     * terms of the GraphLike primitives. A call goes straight to the compile-time-selected body,
+     * so there is no runtime dispatch and no base class to inherit.
+     */
+
+    template <typename = void>
+    bool hasContiguousNodeIds() const {
+        return NetworKit::hasContiguousNodeIds(*this);
+    }
+
+    template <typename L>
+    void forNodes(L handle) const {
+        GraphIterationOps::forNodes(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForNodes(L handle) const {
+        GraphIterationOps::parallelForNodes(*this, handle);
+    }
+
+    template <typename C, typename L>
+    void forNodesWhile(C condition, L handle) const {
+        GraphIterationOps::forNodesWhile(*this, condition, handle);
+    }
+
+    template <typename L>
+    void forNodesInRandomOrder(L handle) const {
+        GraphIterationOps::forNodesInRandomOrder(*this, handle);
+    }
+
+    template <typename L>
+    void balancedParallelForNodes(L handle) const {
+        GraphIterationOps::balancedParallelForNodes(*this, handle);
+    }
+
+    template <typename L>
+    void forNodePairs(L handle) const {
+        GraphIterationOps::forNodePairs(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForNodePairs(L handle) const {
+        GraphIterationOps::parallelForNodePairs(*this, handle);
+    }
+
+    template <typename L>
+    void forEdges(L handle) const {
+        GraphIterationOps::forEdges(*this, handle);
+    }
+
+    template <typename L>
+    void parallelForEdges(L handle) const {
+        GraphIterationOps::parallelForEdges(*this, handle);
+    }
+
+    template <typename L>
+    void forNeighborsOf(node u, L handle) const {
+        GraphIterationOps::forNeighborsOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forEdgesOf(node u, L handle) const {
+        GraphIterationOps::forEdgesOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forInNeighborsOf(node u, L handle) const {
+        GraphIterationOps::forInNeighborsOf(*this, u, handle);
+    }
+
+    template <typename L>
+    void forInEdgesOf(node u, L handle) const {
+        GraphIterationOps::forInEdgesOf(*this, u, handle);
+    }
+
+    template <typename L>
+    double parallelSumForNodes(L handle) const {
+        return GraphIterationOps::parallelSumForNodes(*this, handle);
+    }
+
+    template <typename L>
+    double parallelSumForEdges(L handle) const {
+        return GraphIterationOps::parallelSumForEdges(*this, handle);
+    }
+
+    template <typename = void>
+    edgeweight weightedDegree(node u, bool countSelfLoopsTwice = false) const {
+        return GraphIterationOps::weightedDegree(*this, u, countSelfLoopsTwice);
+    }
+
+    template <typename = void>
+    edgeweight weightedDegreeIn(node u, bool countSelfLoopsTwice = false) const {
+        return GraphIterationOps::weightedDegreeIn(*this, u, countSelfLoopsTwice);
+    }
+
+    template <typename = void>
+    edgeweight totalEdgeWeight() const {
+        return GraphIterationOps::totalEdgeWeight(*this);
+    }
+
+    /// O(1). Requires hasNode(u).
+    count degreeOut(node u) const { return degree(u); }
+
+    /// O(1). Requires hasNode(u).
+    count degreeIn(node u) const {
+        assert(hasNode(u));
+        return directed_ ? inDegree_[u] : outDegree_[u];
+    }
+
+    bool isIsolated(node u) const {
+        if (!hasNode(u))
+            throw std::runtime_error("Error, the node does not exist!");
+        return degree(u) == 0 && (!directed_ || degreeIn(u) == 0);
+    }
+
+    /// O(deg(u)). True when both endpoints are in the view and the base carries the edge.
+    template <typename = void>
+    bool hasEdge(node u, node v) const {
+        if (!hasNode(u) || !hasNode(v))
+            return false;
+        return GraphIterationOps::hasEdge(*this, u, v);
+    }
+
+    /// O(deg(u)); nullWeight when the edge is absent from the view.
+    template <typename = void>
+    edgeweight weight(node u, node v) const {
+        if (!hasNode(u) || !hasNode(v))
+            return nullWeight;
+        return GraphIterationOps::weight(*this, u, v);
+    }
+
+    /* VIEW-SPECIFIC OPERATIONS */
+
+    /// The graph the view spans.
+    const BaseGraph &getBaseGraph() const noexcept { return *base_; }
+
+    /// The members of the subgraph, in ascending id order. O(z).
+    std::vector<node> getNodeSubset() const {
+        std::vector<node> result;
+        result.reserve(n_);
+        for (node u = 0; u < exists_.size(); ++u)
+            if (exists_[u])
+                result.push_back(u);
+        return result;
+    }
+
+    /**
+     * Nodes outside the view that are out-neighbors of a node inside it. Ascending and unique.
+     * This is the search frontier when the view grows one layer at a time.
+     */
+    std::vector<node> frontier() const {
+        std::vector<node> result;
+        for (node u : getNodeSubset())
+            for (const auto nb : base_->template outNeighbors<false>(u)) {
+                const node v = neighborTarget(nb);
+                if (!hasNode(v))
+                    result.push_back(v);
+            }
+        std::sort(result.begin(), result.end());
+        result.erase(std::unique(result.begin(), result.end()), result.end());
+        return result;
+    }
+
+    /**
+     * Constructs an explicit mutable subgraph equivalent to this view.
+     * @param compact Whether the subgraph should get compact node ids instead of the base ids.
+     */
+    GraphW realize(bool compact = false) const {
+        GraphW out(compact ? n_ : upperNodeIdBound(), isWeighted(), directed_);
+        if (compact) {
+            std::vector<node> newId(upperNodeIdBound(), none);
+            node next = 0;
+            forNodes([&](node u) { newId[u] = next++; });
+            forEdges([&](node u, node v, edgeweight w) {
+                out.addEdge(newId[u], newId[v], isWeighted() ? w : defaultEdgeWeight);
+            });
+        } else {
+            for (node u = 0; u < upperNodeIdBound(); ++u)
+                if (!exists_[u])
+                    out.removeNode(u);
+            forEdges([&](node u, node v, edgeweight w) {
+                out.addEdge(u, v, isWeighted() ? w : defaultEdgeWeight);
+            });
+        }
+        return out;
+    }
+
+private:
+    const BaseGraph *base_;
+    /// One presence flag per base node; indexed by the base ids the view keeps.
+    std::vector<char> exists_;
+    std::vector<count> outDegree_;
+    /// Only populated on a directed base.
+    std::vector<count> inDegree_;
+    count n_ = 0, m_ = 0, selfLoops_ = 0;
+    bool directed_;
+
+    template <typename NodeRange>
+    void addNodesImpl(const NodeRange &nodes) {
+        for (const node v : nodes) {
+            if (!base_->hasNode(v))
+                throw std::runtime_error("InducedSubgraphView: node is not in the base graph");
+            insertNode(v);
+        }
+    }
+
+    template <typename NodeRange>
+    void removeNodesImpl(const NodeRange &nodes) {
+        for (const node v : nodes)
+            eraseNode(v);
+    }
+
+    /// Brings the counters in line with @a v joining the subset. Nodes are applied one at a
+    /// time, so edges to nodes added earlier in the same batch are counted exactly once.
+    void insertNode(node v) {
+        if (exists_[v])
+            return;
+        exists_[v] = 1;
+        ++n_;
+
+        count outDeg = 0;
+        for (const auto nb : base_->template outNeighbors<false>(v)) {
+            const node u = neighborTarget(nb);
+            if (!exists_[u])
+                continue;
+            if (!directed_) {
+                if (u == v)
+                    ++selfLoops_;
+                else
+                    ++outDegree_[u];
+            } else {
+                // the edge (v, u) is an in-edge of u
+                ++inDegree_[u];
+                if (u == v)
+                    ++selfLoops_;
+            }
+            ++outDeg;
+        }
+        outDegree_[v] = outDeg;
+        m_ += outDeg;
+
+        if (directed_) {
+            count inDeg = 0;
+            for (const auto nb : base_->template inNeighbors<false>(v)) {
+                const node u = neighborTarget(nb);
+                // a self-loop was already accounted for by the out-scan above
+                if (u == v || !exists_[u])
+                    continue;
+                ++outDegree_[u];
+                ++inDeg;
+            }
+            inDegree_[v] += inDeg;
+            m_ += inDeg;
+        }
+    }
+
+    /// The inverse of insertNode(). @a v stays marked present until its own adjacency has been
+    /// scanned, so a self-loop is seen exactly once.
+    void eraseNode(node v) {
+        if (!exists_[v])
+            return;
+
+        count removedOut = 0;
+        for (const auto nb : base_->template outNeighbors<false>(v)) {
+            const node u = neighborTarget(nb);
+            if (!exists_[u])
+                continue;
+            if (!directed_) {
+                if (u == v)
+                    --selfLoops_;
+                else
+                    --outDegree_[u];
+            } else {
+                --inDegree_[u];
+                if (u == v)
+                    --selfLoops_;
+            }
+            ++removedOut;
+        }
+        m_ -= removedOut;
+
+        if (directed_) {
+            count removedIn = 0;
+            for (const auto nb : base_->template inNeighbors<false>(v)) {
+                const node u = neighborTarget(nb);
+                if (u == v || !exists_[u])
+                    continue;
+                --outDegree_[u];
+                ++removedIn;
+            }
+            m_ -= removedIn;
+            inDegree_[v] = 0;
+        }
+
+        outDegree_[v] = 0;
+        exists_[v] = 0;
+        --n_;
+    }
+};
+
+/*
+ * The concept claims are checked on the two concrete base graphs; a base that satisfies
+ * GraphLike yields an InducedSubgraphView that does too, and any algorithm written as
+ * template <GraphLike G> accepts the view.
+ */
+static_assert(GraphLike<InducedSubgraphView<GraphW>>);
+static_assert(GraphLike<InducedSubgraphView<GraphR>>);
+static_assert(!IndexedGraph<InducedSubgraphView<GraphW>>,
+              "the view does not re-expose the base's edge ids");
+static_assert(!MutableGraph<InducedSubgraphView<GraphW>>,
+              "batch membership edits are not the MutableGraph protocol");
+
+} // namespace NetworKit
+
+#endif // NETWORKIT_GRAPH_INDUCED_SUBGRAPH_VIEW_HPP_

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -431,7 +431,9 @@ private:
     /// The inverse of insertNode(). @a v stays marked present until its own adjacency has been
     /// scanned, so a self-loop is seen exactly once.
     void eraseNode(node v) {
-        if (!exists_[v])
+        // ids outside the base's id space were never inserted; indexing exists_ with them
+        // would read past its storage
+        if (v >= exists_.size() || !exists_[v])
             return;
 
         count removedOut = 0;

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -8,6 +8,7 @@
 #define NETWORKIT_GRAPH_INDUCED_SUBGRAPH_VIEW_HPP_
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <initializer_list>
 #include <ranges>
@@ -33,9 +34,11 @@ namespace NetworKit {
  *
  * Membership is edited in batches (@c addNodes / @c removeNodes). The induced degrees, the edge
  * count and the self-loop count are maintained incrementally while the batch is applied, which
- * keeps every GraphLike primitive O(1). Neighborhoods are never materialized: each range filters
- * the base adjacency on the fly, so the view's memory footprint is one presence flag and one or
- * two degree counters per base node.
+ * keeps every GraphLike primitive O(1). Neighborhoods are never materialized: each range either
+ * filters the base adjacency on the fly or, when the base degree dwarfs the view, walks the view's
+ * members and probes the base for adjacency instead (see NeighborRange), so the view's memory
+ * footprint is one presence flag, one or two degree counters per base node, plus a member index
+ * that is rebuilt lazily after edits.
  *
  * The base graph must outlive the view and must not be modified while the view exists; ranges
  * borrowed from the view are additionally invalidated by any addNodes()/removeNodes() call, just
@@ -135,25 +138,193 @@ public:
     /// The induced self-loop count; maintained incrementally, O(1).
     count numberOfSelfLoops() const noexcept { return selfLoops_; }
 
+private:
     /**
-     * The out-neighbors of @a u inside the view: the base neighborhood filtered by membership.
-     * The range borrows the base graph's storage and this view's flags, and is invalidated by any
-     * membership edit. @tparam Weighted selects the (node, weight) payload; an unweighted base
-     * has no weight array, so only request it when isWeighted() holds.
+     * The neighborhood of @a u restricted to the view, as a forward range. Elements are bare
+     * nodes when @a Weighted is false and (node, weight) pairs otherwise, regardless of how the
+     * base graph represents its neighborhoods.
+     *
+     * Two evaluation strategies produce the same members; the range picks one at construction:
+     *
+     * - scanning @a u's base neighborhood and keeping the subset members (order: base adjacency
+     *   order), or
+     * - walking the subset members ascending and probing the base graph for adjacency (order:
+     *   ascending ids).
+     *
+     * The second strategy engages only while the base neighborhoods stay sorted, so both orders
+     * agree whenever it can run at all. It exists for small views over graphs with skewed
+     * degrees: scanning a hub's whole adjacency costs O(deg(u)) no matter how few induced
+     * neighbors turn up, while the probe-per-member walk costs one binary search each and wins
+     * once deg(u) overshoots n * bit_width(deg(u)) by 4x.
+     */
+    template <bool Weighted, bool Incoming>
+    class NeighborRange {
+        template <bool W>
+        using BaseOutRange = decltype(std::views::all(
+            std::declval<const BaseGraph &>().template outNeighbors<W>(0)));
+        template <bool W>
+        using BaseInRange =
+            decltype(std::views::all(std::declval<const BaseGraph &>().template inNeighbors<W>(0)));
+        using BaseRange =
+            std::conditional_t<Incoming, BaseInRange<Weighted>, BaseOutRange<Weighted>>;
+        // The range travels as const everywhere, so iterators must be taken off the const view.
+        using BaseIt = std::ranges::iterator_t<const BaseRange>;
+        using BaseSent = std::ranges::sentinel_t<const BaseRange>;
+
+    public:
+        using Payload = std::conditional_t<Weighted, std::pair<node, edgeweight>, node>;
+
+        NeighborRange(const InducedSubgraphView &view, node u)
+            : view_(&view), u_(u), scanSubset_(chooseScan()), baseRange_(makeBaseRange()),
+              members_(&view.sortedMembers()) {}
+
+        class iterator {
+        public:
+            using value_type = Payload;
+            using reference = Payload;
+            using difference_type = std::ptrdiff_t;
+            using iterator_concept = std::forward_iterator_tag;
+
+            iterator() noexcept = default;
+
+            iterator(const NeighborRange &range, bool atEnd) : range_(&range), atEnd_(atEnd) {
+                if (atEnd_)
+                    return;
+                if (range_->scanSubset_) {
+                    pos_ = 0;
+                    nextSubset();
+                } else {
+                    baseIt_ = range_->baseRange_.begin();
+                    baseEnd_ = range_->baseRange_.end();
+                    nextBase();
+                }
+            }
+
+            const Payload &operator*() const noexcept { return current_; }
+
+            iterator &operator++() {
+                if (range_->scanSubset_)
+                    nextSubset();
+                else
+                    nextBase();
+                return *this;
+            }
+
+            iterator operator++(int) {
+                iterator copy(*this);
+                ++(*this);
+                return copy;
+            }
+
+            friend bool operator==(const iterator &a, const iterator &b) noexcept {
+                if (a.atEnd_ || b.atEnd_)
+                    return a.atEnd_ && b.atEnd_;
+                if (a.range_ != b.range_)
+                    return false;
+                return a.range_->scanSubset_ ? a.pos_ == b.pos_ : a.baseIt_ == b.baseIt_;
+            }
+
+        private:
+            void nextBase() {
+                while (baseIt_ != baseEnd_) {
+                    const auto nb = *baseIt_;
+                    const node v = neighborTarget(nb);
+                    ++baseIt_;
+                    if (!range_->view_->exists_[v])
+                        continue;
+                    if constexpr (Weighted)
+                        current_ = {v, neighborWeight(nb)};
+                    else
+                        current_ = v;
+                    return;
+                }
+                atEnd_ = true;
+            }
+
+            void nextSubset() {
+                const auto &members = *range_->members_;
+                while (pos_ < members.size()) {
+                    const node v = members[pos_++];
+                    const node from = Incoming ? v : range_->u_;
+                    const node to = Incoming ? range_->u_ : v;
+                    if (!GraphIterationOps::hasEdge(*range_->view_->base_, from, to))
+                        continue;
+                    if constexpr (Weighted)
+                        current_ = {v, GraphIterationOps::weight(*range_->view_->base_, from, to)};
+                    else
+                        current_ = v;
+                    return;
+                }
+                atEnd_ = true;
+            }
+
+            const NeighborRange *range_ = nullptr;
+            bool atEnd_ = false;
+            std::size_t pos_ = 0;
+            BaseIt baseIt_{};
+            BaseSent baseEnd_{};
+            Payload current_{};
+        };
+
+        iterator begin() const { return iterator(*this, false); }
+        iterator end() const { return iterator(*this, true); }
+
+    private:
+        BaseRange makeBaseRange() const {
+            if constexpr (Incoming)
+                return BaseRange(std::views::all(view_->base_->template inNeighbors<Weighted>(u_)));
+            else
+                return BaseRange(
+                    std::views::all(view_->base_->template outNeighbors<Weighted>(u_)));
+        }
+
+        count baseDegree() const {
+            if constexpr (Incoming && requires { view_->base_->degreeIn(u_); })
+                return view_->base_->degreeIn(u_);
+            else if constexpr (!Incoming && requires { view_->base_->degree(u_); })
+                return view_->base_->degree(u_);
+            else if constexpr (Incoming)
+                return GraphIterationOps::degreeIn(*view_->base_, u_);
+            else
+                return GraphIterationOps::degreeOut(*view_->base_, u_);
+        }
+
+        bool chooseScan() const {
+            constexpr bool sortable = requires(const BaseGraph &g) { g.hasSortedNeighborhoods(); };
+            if constexpr (!sortable)
+                return false;
+            else {
+                const count deg = baseDegree();
+                return deg > 0 && view_->hasSortedNeighborhoods()
+                       && deg > view_->n_ * std::bit_width(deg) * 4;
+            }
+        }
+
+        const InducedSubgraphView *view_;
+        node u_;
+        bool scanSubset_;
+        BaseRange baseRange_;
+        const std::vector<node> *members_;
+    };
+
+public:
+    /**
+     * The out-neighbors of @a u inside the view. The range borrows the base graph's storage and
+     * this view's flags, and is invalidated by any membership edit. @tparam Weighted selects the
+     * (node, weight) payload; an unweighted base has no weight array, so only request it when
+     * isWeighted() holds.
      */
     template <bool Weighted>
-    auto outNeighbors(node u) const {
+    NeighborRange<Weighted, false> outNeighbors(node u) const {
         assert(hasNode(u));
-        return std::ranges::owning_view(base_->template outNeighbors<Weighted>(u))
-               | std::views::filter([this](const auto &nb) { return hasNode(neighborTarget(nb)); });
+        return NeighborRange<Weighted, false>(*this, u);
     }
 
     /// The in-neighbors of @a u inside the view. On an undirected base these are the out-neighbors.
     template <bool Weighted>
-    auto inNeighbors(node u) const {
+    NeighborRange<Weighted, true> inNeighbors(node u) const {
         assert(hasNode(u));
-        return std::ranges::owning_view(base_->template inNeighbors<Weighted>(u))
-               | std::views::filter([this](const auto &nb) { return hasNode(neighborTarget(nb)); });
+        return NeighborRange<Weighted, true>(*this, u);
     }
 
     auto neighborRange(node u) const { return outNeighbors<false>(u); }
@@ -308,15 +479,10 @@ public:
     /// The graph the view spans.
     const BaseGraph &getBaseGraph() const noexcept { return *base_; }
 
-    /// The members of the subgraph, in ascending id order. O(z).
-    std::vector<node> getNodeSubset() const {
-        std::vector<node> result;
-        result.reserve(n_);
-        for (node u = 0; u < exists_.size(); ++u)
-            if (exists_[u])
-                result.push_back(u);
-        return result;
-    }
+    /// The members of the subgraph, in ascending id order. Ascending is what the adaptive
+    /// neighbor ranges rely on; the index is rebuilt lazily after membership edits. O(z) once per
+    /// edit batch, O(1) otherwise.
+    const std::vector<node> &getNodeSubset() const { return sortedMembers(); }
 
     /**
      * Nodes outside the view that are out-neighbors of a node inside it. Ascending and unique.
@@ -369,6 +535,22 @@ private:
     count n_ = 0, m_ = 0, selfLoops_ = 0;
     bool directed_;
 
+    /// Ascending member ids, derived from exists_ on demand; see NeighborRange and
+    /// getNodeSubset(). Mutable because a const range must be able to rebuild it.
+    mutable std::vector<node> sortedMembers_;
+    mutable bool membersDirty_ = true;
+
+    const std::vector<node> &sortedMembers() const {
+        if (membersDirty_) {
+            sortedMembers_.clear();
+            for (node v = 0; v < exists_.size(); ++v)
+                if (exists_[v])
+                    sortedMembers_.push_back(v);
+            membersDirty_ = false;
+        }
+        return sortedMembers_;
+    }
+
     template <typename NodeRange>
     void addNodesImpl(const NodeRange &nodes) {
         for (const node v : nodes) {
@@ -391,6 +573,7 @@ private:
             return;
         exists_[v] = 1;
         ++n_;
+        membersDirty_ = true;
 
         count outDeg = 0;
         for (const auto nb : base_->template outNeighbors<false>(v)) {
@@ -471,6 +654,7 @@ private:
         outDegree_[v] = 0;
         exists_[v] = 0;
         --n_;
+        membersDirty_ = true;
     }
 };
 

--- a/include/networkit/graph/InducedSubgraphView.hpp
+++ b/include/networkit/graph/InducedSubgraphView.hpp
@@ -138,7 +138,6 @@ public:
     /// The induced self-loop count; maintained incrementally, O(1).
     count numberOfSelfLoops() const noexcept { return selfLoops_; }
 
-private:
     /**
      * The neighborhood of @a u restricted to the view, as a forward range. Elements are bare
      * nodes when @a Weighted is false and (node, weight) pairs otherwise, regardless of how the
@@ -167,17 +166,54 @@ private:
             decltype(std::views::all(std::declval<const BaseGraph &>().template inNeighbors<W>(0)));
         using BaseRange =
             std::conditional_t<Incoming, BaseInRange<Weighted>, BaseOutRange<Weighted>>;
-        // The range travels as const everywhere, so iterators must be taken off the const view.
+        // The shared handle below hands out a const range, so iterators come off the const view.
         using BaseIt = std::ranges::iterator_t<const BaseRange>;
         using BaseSent = std::ranges::sentinel_t<const BaseRange>;
+
+        static std::shared_ptr<const BaseRange> makeBaseRange(const InducedSubgraphView &view,
+                                                              node u) {
+            if constexpr (Incoming)
+                return std::make_shared<BaseRange>(
+                    std::views::all(view.base_->template inNeighbors<Weighted>(u)));
+            else
+                return std::make_shared<BaseRange>(
+                    std::views::all(view.base_->template outNeighbors<Weighted>(u)));
+        }
+
+        static count baseDegree(const InducedSubgraphView &view, node u) {
+            if constexpr (Incoming && requires { view.base_->degreeIn(u); })
+                return view.base_->degreeIn(u);
+            else if constexpr (!Incoming && requires { view.base_->degree(u); })
+                return view.base_->degree(u);
+            else if constexpr (Incoming)
+                return GraphIterationOps::degreeIn(*view.base_, u);
+            else
+                return GraphIterationOps::degreeOut(*view.base_, u);
+        }
+
+        static bool chooseScan(const InducedSubgraphView &view, node u) {
+            constexpr bool sortable = requires(const BaseGraph &g) { g.hasSortedNeighborhoods(); };
+            if constexpr (!sortable)
+                return false;
+            else {
+                const count deg = baseDegree(view, u);
+                return deg > 0 && view.hasSortedNeighborhoods()
+                       && deg > view.n_ * std::bit_width(deg) * 4;
+            }
+        }
 
     public:
         using Payload = std::conditional_t<Weighted, std::pair<node, edgeweight>, node>;
 
         NeighborRange(const InducedSubgraphView &view, node u)
-            : view_(&view), u_(u), scanSubset_(chooseScan()), baseRange_(makeBaseRange()),
+            : view_(&view), u_(u), scanSubset_(chooseScan(view, u)), base_(makeBaseRange(view, u)),
               members_(&view.sortedMembers()) {}
 
+        /**
+         * A self-contained cursor: it carries its own copy of the borrowed base range (kept
+         * alive through the shared handle), so iterators survive the temporary range object they
+         * were created from -- which the type-erased handles rely on.
+         */
         class iterator {
         public:
             using value_type = Payload;
@@ -187,15 +223,17 @@ private:
 
             iterator() noexcept = default;
 
-            iterator(const NeighborRange &range, bool atEnd) : range_(&range), atEnd_(atEnd) {
+            iterator(const NeighborRange &range, bool atEnd)
+                : view_(range.view_), u_(range.u_), scanSubset_(range.scanSubset_),
+                  base_(range.base_), members_(range.members_), atEnd_(atEnd) {
                 if (atEnd_)
                     return;
-                if (range_->scanSubset_) {
+                if (scanSubset_) {
                     pos_ = 0;
                     nextSubset();
                 } else {
-                    baseIt_ = range_->baseRange_.begin();
-                    baseEnd_ = range_->baseRange_.end();
+                    baseIt_ = base_->begin();
+                    baseEnd_ = base_->end();
                     nextBase();
                 }
             }
@@ -203,7 +241,7 @@ private:
             const Payload &operator*() const noexcept { return current_; }
 
             iterator &operator++() {
-                if (range_->scanSubset_)
+                if (scanSubset_)
                     nextSubset();
                 else
                     nextBase();
@@ -219,9 +257,7 @@ private:
             bool operator==(const iterator &other) const noexcept {
                 if (atEnd_ || other.atEnd_)
                     return atEnd_ && other.atEnd_;
-                if (range_ != other.range_)
-                    return false;
-                return range_->scanSubset_ ? pos_ == other.pos_ : baseIt_ == other.baseIt_;
+                return scanSubset_ ? pos_ == other.pos_ : baseIt_ == other.baseIt_;
             }
 
         private:
@@ -230,7 +266,7 @@ private:
                     const auto nb = *baseIt_;
                     const node v = neighborTarget(nb);
                     ++baseIt_;
-                    if (!range_->view_->exists_[v])
+                    if (!view_->exists_[v])
                         continue;
                     if constexpr (Weighted)
                         current_ = {v, neighborWeight(nb)};
@@ -242,15 +278,15 @@ private:
             }
 
             void nextSubset() {
-                const auto &members = *range_->members_;
+                const auto &members = *members_;
                 while (pos_ < members.size()) {
                     const node v = members[pos_++];
-                    const node from = Incoming ? v : range_->u_;
-                    const node to = Incoming ? range_->u_ : v;
-                    if (!GraphIterationOps::hasEdge(*range_->view_->base_, from, to))
+                    const node from = Incoming ? v : u_;
+                    const node to = Incoming ? u_ : v;
+                    if (!GraphIterationOps::hasEdge(*view_->base_, from, to))
                         continue;
                     if constexpr (Weighted)
-                        current_ = {v, GraphIterationOps::weight(*range_->view_->base_, from, to)};
+                        current_ = {v, GraphIterationOps::weight(*view_->base_, from, to)};
                     else
                         current_ = v;
                     return;
@@ -258,7 +294,11 @@ private:
                 atEnd_ = true;
             }
 
-            const NeighborRange *range_ = nullptr;
+            const InducedSubgraphView *view_ = nullptr;
+            node u_ = none;
+            bool scanSubset_ = false;
+            std::shared_ptr<const BaseRange> base_{};
+            const std::vector<node> *members_ = nullptr;
             bool atEnd_ = false;
             std::size_t pos_ = 0;
             BaseIt baseIt_{};
@@ -270,40 +310,10 @@ private:
         iterator end() const { return iterator(*this, true); }
 
     private:
-        BaseRange makeBaseRange() const {
-            if constexpr (Incoming)
-                return BaseRange(std::views::all(view_->base_->template inNeighbors<Weighted>(u_)));
-            else
-                return BaseRange(
-                    std::views::all(view_->base_->template outNeighbors<Weighted>(u_)));
-        }
-
-        count baseDegree() const {
-            if constexpr (Incoming && requires { view_->base_->degreeIn(u_); })
-                return view_->base_->degreeIn(u_);
-            else if constexpr (!Incoming && requires { view_->base_->degree(u_); })
-                return view_->base_->degree(u_);
-            else if constexpr (Incoming)
-                return GraphIterationOps::degreeIn(*view_->base_, u_);
-            else
-                return GraphIterationOps::degreeOut(*view_->base_, u_);
-        }
-
-        bool chooseScan() const {
-            constexpr bool sortable = requires(const BaseGraph &g) { g.hasSortedNeighborhoods(); };
-            if constexpr (!sortable)
-                return false;
-            else {
-                const count deg = baseDegree();
-                return deg > 0 && view_->hasSortedNeighborhoods()
-                       && deg > view_->n_ * std::bit_width(deg) * 4;
-            }
-        }
-
         const InducedSubgraphView *view_;
         node u_;
         bool scanSubset_;
-        BaseRange baseRange_;
+        std::shared_ptr<const BaseRange> base_;
         const std::vector<node> *members_;
     };
 
@@ -339,6 +349,12 @@ public:
         else
             return false;
     }
+
+    /// Whether lookups may bisect: exactly when the borrowed neighborhoods are sorted.
+    bool getKeepEdgesSorted() const { return hasSortedNeighborhoods(); }
+
+    /// Tag for the type-erased handle: this arm's ranges travel through AnyNeighborCursor.
+    constexpr bool isInducedSubgraph() const noexcept { return true; }
 
     /* ITERATION, LOOKUPS, AND WEIGHT AGGREGATES (free operations) */
 
@@ -472,6 +488,112 @@ public:
         if (!hasNode(u) || !hasNode(v))
             return nullWeight;
         return GraphIterationOps::weight(*this, u, v);
+    }
+
+    /* EDGE IDS AND INDEXED NEIGHBOR ACCESS */
+
+    /// A view stores no edges of its own, so it assigns no edge ids.
+    bool hasEdgeIds() const noexcept { return false; }
+
+    index upperEdgeIdBound() const noexcept { return none; }
+
+    /// Nothing to maintain without edge ids; mirrors the concrete graphs' knob.
+    bool getMaintainCompactEdges() const noexcept { return true; }
+
+    /**
+     * Recomputes the node, edge, and self-loop counts straight from the base graph and reports
+     * whether they agree with the incrementally maintained ones. O(z + m).
+     */
+    bool checkConsistency() const {
+        count n = 0;
+        count ordered = 0; // sightings of an induced edge from one of its endpoints
+        count loops = 0;
+        for (const node u : sortedMembers()) {
+            ++n;
+            for (const auto nb : base_->template outNeighbors<false>(u)) {
+                const node v = neighborTarget(nb);
+                if (!exists_[v])
+                    continue;
+                ++ordered;
+                if (u == v)
+                    ++loops;
+            }
+        }
+        const count m = directed_ ? ordered : (ordered + loops) / 2;
+        return n == n_ && m == m_ && loops == selfLoops_;
+    }
+
+    /**
+     * The @a i-th member of @a u's induced neighborhood, or @c none when @a i is out of range.
+     * Members appear in the adaptive range's order -- base adjacency order, which is ascending on
+     * sorted bases. O(deg(u)).
+     */
+    node getIthNeighbor(node u, index i) const {
+        if (!hasNode(u) || i >= degree(u))
+            return none;
+        return getIthNeighbor(Unsafe{}, u, i);
+    }
+
+    node getIthNeighbor(Unsafe, node u, index i) const {
+        count j = 0;
+        for (const auto nb : outNeighbors<false>(u))
+            if (j++ == i)
+                return neighborTarget(nb);
+        return none;
+    }
+
+    /// As getIthNeighbor, over the induced in-neighborhood.
+    node getIthInNeighbor(node u, index i) const {
+        if (!hasNode(u) || i >= degreeIn(u))
+            return none;
+        count j = 0;
+        for (const auto nb : inNeighbors<false>(u))
+            if (j++ == i)
+                return neighborTarget(nb);
+        return none;
+    }
+
+    /// The weight of the @a i-th induced neighbor of @a u, or @c none when @a i is out of range.
+    edgeweight getIthNeighborWeight(node u, index i) const {
+        if (!hasNode(u) || i >= degree(u))
+            return nullWeight;
+        return getIthNeighborWeight(Unsafe{}, u, i);
+    }
+
+    edgeweight getIthNeighborWeight(Unsafe, node u, index i) const {
+        count j = 0;
+        for (const auto nb : outNeighbors<true>(u))
+            if (j++ == i)
+                return neighborWeight(nb);
+        return nullWeight;
+    }
+
+    /// The @a i-th induced neighbor of @a u with its weight, or (@c none, @c nullWeight).
+    std::pair<node, edgeweight> getIthNeighborWithWeight(node u, index i) const {
+        if (!hasNode(u) || i >= degree(u))
+            return {none, nullWeight};
+        return getIthNeighborWithWeight(Unsafe{}, u, i);
+    }
+
+    std::pair<node, edgeweight> getIthNeighborWithWeight(Unsafe, node u, index i) const {
+        count j = 0;
+        for (const auto nb : outNeighbors<true>(u))
+            if (j++ == i)
+                return {neighborTarget(nb), neighborWeight(nb)};
+        return {none, nullWeight};
+    }
+
+    /// The position of @a v in @a u's induced neighborhood, or @c none when absent. O(deg(u)).
+    index indexOfNeighbor(node u, node v) const {
+        if (!hasNode(u) || !hasNode(v))
+            return none;
+        index i = 0;
+        for (const auto nb : outNeighbors<false>(u)) {
+            if (neighborTarget(nb) == v)
+                return i;
+            ++i;
+        }
+        return none;
     }
 
     /* VIEW-SPECIFIC OPERATIONS */

--- a/include/networkit/graph/ReferenceGraph.hpp
+++ b/include/networkit/graph/ReferenceGraph.hpp
@@ -254,20 +254,19 @@ public:
     }
 
     /*
-     * Explicit so that converting a concrete graph by value goes through SelfHandled's
-     * conversion operator. With both routes available g++ silently materializes a temporary
-     * while clang++ rejects the call as ambiguous.
+     * Explicit so that converting a graph goes through that graph's SelfHandled conversion
+     * operator, which yields the handle embedded inside it. With both routes available g++
+     * silently materializes a temporary while clang++ rejects the call as ambiguous -- and a
+     * temporary would dangle the moment an algorithm stored the reference it was given.
+     *
+     * The views take the same route: only the two arm instantiations derive SelfHandled (a view
+     * of a view has no handle to embed), and their operator keeps "Algorithm(view)" implicit
+     * while binding to the embedded, identity-bound handle.
      */
     explicit ReferenceGraph(const GraphW &g) noexcept : arm_(&g) {}
     explicit ReferenceGraph(const GraphR &g) noexcept : arm_(&g) {}
-
-    /**
-     * Implicit on purpose, unlike the concrete-graph conversions above: those guard against
-     * SelfHandled's by-value conversion operator materializing a temporary, while a view is only
-     * ever bound by address -- and "Algorithm(view)" is exactly the ergonomics views exist for.
-     */
-    ReferenceGraph(const InducedSubgraphView<GraphW> &g) noexcept : arm_(&g) {}
-    ReferenceGraph(const InducedSubgraphView<GraphR> &g) noexcept : arm_(&g) {}
+    explicit ReferenceGraph(const InducedSubgraphView<GraphW> &g) noexcept : arm_(&g) {}
+    explicit ReferenceGraph(const InducedSubgraphView<GraphR> &g) noexcept : arm_(&g) {}
 
     /// Calls @a f with a reference to the concrete graph, instantiating it once per arm.
     template <typename Fn>

--- a/include/networkit/graph/ReferenceGraph.hpp
+++ b/include/networkit/graph/ReferenceGraph.hpp
@@ -141,6 +141,28 @@ public:
     /// References a shared empty read-only graph. Required so Cython can materialize temporaries.
     ReferenceGraph() noexcept;
 
+    /**
+     * The out-neighbors of @a u, as an erased range over the referenced graph's own storage.
+     * These two templates are what makes a ReferenceGraph itself satisfy GraphLike, so views and
+     * algorithms generic over the concept accept a type-erased handle directly.
+     */
+    template <bool Weighted>
+    auto outNeighbors(node u) const {
+        if constexpr (Weighted)
+            return weightNeighborRange(u);
+        else
+            return neighborRange(u);
+    }
+
+    /// The in-neighbors of @a u. On an undirected graph these are the out-neighbors.
+    template <bool Weighted>
+    auto inNeighbors(node u) const {
+        if constexpr (Weighted)
+            return weightInNeighborRange(u);
+        else
+            return inNeighborRange(u);
+    }
+
     /*
      * Explicit so that converting a concrete graph by value goes through SelfHandled's
      * conversion operator. With both routes available g++ silently materializes a temporary

--- a/include/networkit/graph/ReferenceGraph.hpp
+++ b/include/networkit/graph/ReferenceGraph.hpp
@@ -26,6 +26,15 @@ class GraphR;
 class GraphW;
 
 /**
+ * The two instantiations the handle knows. The view is deliberately absent from every other
+ * position: its bases are concrete graphs only, which is what bounds template instantiation when
+ * a handle member (say, outNeighbors) reaches into a view arm and the view reaches back into its
+ * base.
+ */
+template <typename BaseGraph>
+class InducedSubgraphView;
+
+/**
  * A handle to some concrete graph, resolved statically rather than through a vtable.
  *
  * Non-owning: the referenced graph must outlive the handle. Copying copies a pointer, never a
@@ -33,7 +42,9 @@ class GraphW;
  * the concrete type.
  */
 class ReferenceGraph {
-    std::variant<const GraphW *, const GraphR *> arm_;
+    std::variant<const GraphW *, const GraphR *, const InducedSubgraphView<GraphW> *,
+                 const InducedSubgraphView<GraphR> *>
+        arm_;
 
 public:
     using NodeIterator = NodeIteratorBase<ReferenceGraph>;
@@ -60,9 +71,87 @@ public:
         bool operator==(const NeighborCursor &) const = default;
     };
 
-    template <typename Payload, typename... ArmIters>
+    /**
+     * A cursor over an arm range whose iterator type cannot be named where the handle is
+     * declared -- today, the induced-subgraph-view arms. The Impl header binds the concrete
+     * iterators; every step pays one virtual call, which is noise next to the filtering and
+     * probing those ranges already do per element.
+     */
+    template <typename Payload>
+    class AnyNeighborCursor {
+        struct Concept {
+            virtual ~Concept() = default;
+            virtual std::unique_ptr<Concept> clone() const = 0;
+            virtual bool done() const = 0;
+            virtual Payload get() const = 0;
+            virtual void next() = 0;
+            virtual bool equals(const Concept &other) const = 0;
+        };
+
+        template <typename Range>
+        struct Model final : Concept {
+            using It = std::ranges::iterator_t<const Range>;
+
+            std::shared_ptr<const Range> range;
+            It cur{};
+            bool atEnd = false;
+
+            Model(std::shared_ptr<const Range> r, bool end)
+                : range(std::move(r)), cur(range->begin()), atEnd(end) {}
+
+            std::unique_ptr<Concept> clone() const override {
+                return std::make_unique<Model>(*this);
+            }
+            bool done() const override { return atEnd || cur == range->end(); }
+            Payload get() const override { return static_cast<Payload>(*cur); }
+            void next() override {
+                assert(!done());
+                ++cur;
+            }
+            bool equals(const Concept &other) const override {
+                const auto *o = dynamic_cast<const Model *>(&other);
+                if (o == nullptr || o->range != range)
+                    return false;
+                const bool mine = done(), theirs = o->done();
+                return mine != theirs ? false : (mine ? true : cur == o->cur);
+            }
+        };
+
+        std::unique_ptr<Concept> model_;
+
+        explicit AnyNeighborCursor(std::unique_ptr<Concept> m) : model_(std::move(m)) {}
+
+    public:
+        AnyNeighborCursor() = default;
+        AnyNeighborCursor(const AnyNeighborCursor &other)
+            : model_(other.model_ ? other.model_->clone() : nullptr) {}
+        AnyNeighborCursor &operator=(const AnyNeighborCursor &other) {
+            if (this != &other)
+                model_ = other.model_ ? other.model_->clone() : nullptr;
+            return *this;
+        }
+        AnyNeighborCursor(AnyNeighborCursor &&) noexcept = default;
+        AnyNeighborCursor &operator=(AnyNeighborCursor &&) noexcept = default;
+
+        bool done() const { return !model_ || model_->done(); }
+        Payload get() const { return model_->get(); }
+        void next() { model_->next(); }
+        bool operator==(const AnyNeighborCursor &other) const {
+            if (!model_ || !other.model_)
+                return model_.get() == other.model_.get();
+            return model_->equals(*other.model_);
+        }
+
+        /// Takes ownership of a materialized arm range; @a end selects the end cursor.
+        template <typename Range>
+        static AnyNeighborCursor over(std::shared_ptr<const Range> range, bool end) {
+            return AnyNeighborCursor(std::make_unique<Model<Range>>(std::move(range), end));
+        }
+    };
+
+    template <typename Payload, typename... Cursors>
     class ErasedNeighborIterator {
-        std::variant<NeighborCursor<ArmIters>...> cursor_;
+        std::variant<Cursors...> cursor_;
 
     public:
         using value_type = Payload;
@@ -91,21 +180,22 @@ public:
             return std::visit(
                 [&o](const auto &a) {
                     const auto *b = std::get_if<std::decay_t<decltype(a)>>(&o.cursor_);
-                    return b != nullptr && a.cur == b->cur;
+                    return b != nullptr && a == *b;
                 },
                 cursor_);
         }
         bool operator!=(const ErasedNeighborIterator &o) const { return !(*this == o); }
     };
 
-    using NeighborIterator =
-        ErasedNeighborIterator<node, NeighborIteratorBase<std::vector<node>::const_iterator>,
-                               NeighborIteratorBase<const node *>>;
-    using NeighborWeightIterator =
-        ErasedNeighborIterator<std::pair<node, edgeweight>,
-                               NeighborWeightIteratorBase<std::vector<node>::const_iterator,
-                                                          std::vector<edgeweight>::const_iterator>,
-                               NeighborWeightIteratorBase<const node *, const edgeweight *>>;
+    using NeighborIterator = ErasedNeighborIterator<
+        node, NeighborCursor<NeighborIteratorBase<std::vector<node>::const_iterator>>,
+        NeighborCursor<NeighborIteratorBase<const node *>>, AnyNeighborCursor<node>>;
+    using NeighborWeightIterator = ErasedNeighborIterator<
+        std::pair<node, edgeweight>,
+        NeighborCursor<NeighborWeightIteratorBase<std::vector<node>::const_iterator,
+                                                  std::vector<edgeweight>::const_iterator>>,
+        NeighborCursor<NeighborWeightIteratorBase<const node *, const edgeweight *>>,
+        AnyNeighborCursor<std::pair<node, edgeweight>>>;
 
     /// The neighbors of a node, borrowed from the arm's own storage; nothing is copied.
     template <bool InEdges = false>
@@ -171,6 +261,14 @@ public:
     explicit ReferenceGraph(const GraphW &g) noexcept : arm_(&g) {}
     explicit ReferenceGraph(const GraphR &g) noexcept : arm_(&g) {}
 
+    /**
+     * Implicit on purpose, unlike the concrete-graph conversions above: those guard against
+     * SelfHandled's by-value conversion operator materializing a temporary, while a view is only
+     * ever bound by address -- and "Algorithm(view)" is exactly the ergonomics views exist for.
+     */
+    ReferenceGraph(const InducedSubgraphView<GraphW> &g) noexcept : arm_(&g) {}
+    ReferenceGraph(const InducedSubgraphView<GraphR> &g) noexcept : arm_(&g) {}
+
     /// Calls @a f with a reference to the concrete graph, instantiating it once per arm.
     template <typename Fn>
     decltype(auto) visit(Fn &&f) const;
@@ -195,8 +293,9 @@ public:
     edgeweight totalEdgeWeight() const noexcept;
     bool checkConsistency() const;
 
-    const AttributeMap<PerNode, ReferenceGraph> &nodeAttributes() const noexcept;
-    const AttributeMap<PerEdge, ReferenceGraph> &edgeAttributes() const noexcept;
+    /// Throws when the arm carries no attributes (the views do not).
+    const AttributeMap<PerNode, ReferenceGraph> &nodeAttributes() const;
+    const AttributeMap<PerEdge, ReferenceGraph> &edgeAttributes() const;
 
     /* NODE AND EDGE PROPERTIES */
 

--- a/include/networkit/graph/ReferenceGraphImpl.hpp
+++ b/include/networkit/graph/ReferenceGraphImpl.hpp
@@ -282,6 +282,12 @@ double ReferenceGraph::parallelSumForEdges(L handle) const {
     return visit([&](const auto &g) { return g.parallelSumForEdges(handle); });
 }
 
+static_assert(GraphLike<ReferenceGraph>,
+              "the type-erased handle must be usable wherever a graph type is");
+static_assert(!IndexedGraph<ReferenceGraph>,
+              "edge ids are only carried by graphs that index their edges");
+static_assert(!MutableGraph<ReferenceGraph>, "a handle cannot mutate the referenced graph");
+
 } // namespace NetworKit
 
 #endif // NETWORKIT_GRAPH_REFERENCE_GRAPH_IMPL_HPP_

--- a/include/networkit/graph/ReferenceGraphImpl.hpp
+++ b/include/networkit/graph/ReferenceGraphImpl.hpp
@@ -43,12 +43,6 @@ inline ReferenceGraph refGraphW(const GraphW &g) {
 inline ReferenceGraph refGraphR(const GraphR &g) {
     return ReferenceGraph(g);
 }
-inline ReferenceGraph refGraphVW(const InducedSubgraphView<GraphW> &g) {
-    return ReferenceGraph(g);
-}
-inline ReferenceGraph refGraphVR(const InducedSubgraphView<GraphR> &g) {
-    return ReferenceGraph(g);
-}
 
 /* GLOBAL PROPERTIES */
 

--- a/include/networkit/graph/ReferenceGraphImpl.hpp
+++ b/include/networkit/graph/ReferenceGraphImpl.hpp
@@ -9,12 +9,14 @@
 #define NETWORKIT_GRAPH_REFERENCE_GRAPH_IMPL_HPP_
 
 #include <ranges>
+#include <stdexcept>
 #include <utility>
 #include <variant>
 
 #include <networkit/graph/GraphIteration.hpp>
 #include <networkit/graph/GraphR.hpp>
 #include <networkit/graph/GraphW.hpp>
+#include <networkit/graph/InducedSubgraphView.hpp>
 #include <networkit/graph/ReferenceGraph.hpp>
 
 namespace NetworKit {
@@ -39,6 +41,12 @@ inline ReferenceGraph refGraphW(const GraphW &g) {
     return ReferenceGraph(g);
 }
 inline ReferenceGraph refGraphR(const GraphR &g) {
+    return ReferenceGraph(g);
+}
+inline ReferenceGraph refGraphVW(const InducedSubgraphView<GraphW> &g) {
+    return ReferenceGraph(g);
+}
+inline ReferenceGraph refGraphVR(const InducedSubgraphView<GraphR> &g) {
     return ReferenceGraph(g);
 }
 
@@ -83,13 +91,21 @@ inline edgeweight ReferenceGraph::totalEdgeWeight() const noexcept {
 inline bool ReferenceGraph::checkConsistency() const {
     return visit([](const auto &g) { return g.checkConsistency(); });
 }
-inline const AttributeMap<PerNode, ReferenceGraph> &
-ReferenceGraph::nodeAttributes() const noexcept {
-    return visit([](const auto &g) -> decltype(auto) { return g.nodeAttributes(); });
+inline const AttributeMap<PerNode, ReferenceGraph> &ReferenceGraph::nodeAttributes() const {
+    return visit([&](const auto &g) -> const AttributeMap<PerNode, ReferenceGraph> & {
+        if constexpr (requires { g.nodeAttributes(); })
+            return g.nodeAttributes();
+        else
+            throw std::runtime_error("attributes are not supported on this graph");
+    });
 }
-inline const AttributeMap<PerEdge, ReferenceGraph> &
-ReferenceGraph::edgeAttributes() const noexcept {
-    return visit([](const auto &g) -> decltype(auto) { return g.edgeAttributes(); });
+inline const AttributeMap<PerEdge, ReferenceGraph> &ReferenceGraph::edgeAttributes() const {
+    return visit([&](const auto &g) -> const AttributeMap<PerEdge, ReferenceGraph> & {
+        if constexpr (requires { g.edgeAttributes(); })
+            return g.edgeAttributes();
+        else
+            throw std::runtime_error("attributes are not supported on this graph");
+    });
 }
 
 /* NODE AND EDGE PROPERTIES */
@@ -122,10 +138,20 @@ inline edgeweight ReferenceGraph::weight(node u, node v) const {
     return visit([u, v](const auto &g) { return g.weight(u, v); });
 }
 inline edgeid ReferenceGraph::edgeId(node u, node v) const {
-    return visit([u, v](const auto &g) { return g.edgeId(u, v); });
+    return visit([&](const auto &g) -> edgeid {
+        if constexpr (requires { g.edgeId(u, v); })
+            return g.edgeId(u, v);
+        else
+            throw std::runtime_error("this graph does not maintain edge ids");
+    });
 }
 inline std::pair<node, node> ReferenceGraph::edgeById(index id) const {
-    return visit([id](const auto &g) { return g.edgeById(id); });
+    return visit([&](const auto &g) -> std::pair<node, node> {
+        if constexpr (requires { g.edgeById(id); })
+            return g.edgeById(id);
+        else
+            throw std::runtime_error("this graph does not maintain edge ids");
+    });
 }
 
 /* INDEXED NEIGHBOR ACCESS */
@@ -156,7 +182,12 @@ inline std::pair<node, edgeweight> ReferenceGraph::getIthNeighborWithWeight(Unsa
     return visit([u, i](const auto &g) { return g.getIthNeighborWithWeight(Unsafe{}, u, i); });
 }
 inline std::pair<node, edgeid> ReferenceGraph::getIthNeighborWithId(node u, index i) const {
-    return visit([u, i](const auto &g) { return g.getIthNeighborWithId(u, i); });
+    return visit([&](const auto &g) -> std::pair<node, edgeid> {
+        if constexpr (requires { g.getIthNeighborWithId(u, i); })
+            return g.getIthNeighborWithId(u, i);
+        else
+            throw std::runtime_error("this graph does not maintain edge ids");
+    });
 }
 /* RANGES */
 
@@ -187,20 +218,40 @@ auto neighborsOf(const G &g, node u) {
 template <bool InEdges>
 ReferenceGraph::NeighborRange<InEdges>::NeighborRange(const ReferenceGraph &G, node u) {
     G.visit([&](const auto &g) {
-        auto r = ReferenceGraphDetail::neighborsOf<InEdges, false>(g, u);
-        using Cur = NeighborCursor<std::ranges::iterator_t<decltype(r)>>;
-        first = NeighborIterator(Cur{r.begin(), r.end()});
-        last = NeighborIterator(Cur{r.end(), r.end()});
+        if constexpr (requires { g.isInducedSubgraph(); }) {
+            // The view's iterators cannot be named here; erase them behind a cursor that owns
+            // the materialized base range.
+            auto r = ReferenceGraphDetail::neighborsOf<InEdges, false>(g, u);
+            using Rng = std::decay_t<decltype(r)>;
+            auto owned = std::make_shared<const Rng>(std::move(r));
+            first = NeighborIterator(AnyNeighborCursor<node>::over(owned, false));
+            last = NeighborIterator(AnyNeighborCursor<node>::over(std::move(owned), true));
+        } else {
+            auto r = ReferenceGraphDetail::neighborsOf<InEdges, false>(g, u);
+            using Cur = NeighborCursor<std::ranges::iterator_t<decltype(r)>>;
+            first = NeighborIterator(Cur{r.begin(), r.end()});
+            last = NeighborIterator(Cur{r.end(), r.end()});
+        }
     });
 }
 
 template <bool InEdges>
 ReferenceGraph::NeighborWeightRange<InEdges>::NeighborWeightRange(const ReferenceGraph &G, node u) {
     G.visit([&](const auto &g) {
-        auto r = ReferenceGraphDetail::neighborsOf<InEdges, true>(g, u);
-        using Cur = NeighborCursor<std::ranges::iterator_t<decltype(r)>>;
-        first = NeighborWeightIterator(Cur{r.begin(), r.end()});
-        last = NeighborWeightIterator(Cur{r.end(), r.end()});
+        if constexpr (requires { g.isInducedSubgraph(); }) {
+            auto r = ReferenceGraphDetail::neighborsOf<InEdges, true>(g, u);
+            using Rng = std::decay_t<decltype(r)>;
+            auto owned = std::make_shared<const Rng>(std::move(r));
+            first = NeighborWeightIterator(
+                AnyNeighborCursor<std::pair<node, edgeweight>>::over(owned, false));
+            last = NeighborWeightIterator(
+                AnyNeighborCursor<std::pair<node, edgeweight>>::over(std::move(owned), true));
+        } else {
+            auto r = ReferenceGraphDetail::neighborsOf<InEdges, true>(g, u);
+            using Cur = NeighborCursor<std::ranges::iterator_t<decltype(r)>>;
+            first = NeighborWeightIterator(Cur{r.begin(), r.end()});
+            last = NeighborWeightIterator(Cur{r.end(), r.end()});
+        }
     });
 }
 

--- a/networkit/cpp/coarsening/CoarsenedGraphView.cpp
+++ b/networkit/cpp/coarsening/CoarsenedGraphView.cpp
@@ -59,7 +59,7 @@ CoarsenedGraphView::CoarsenedGraphView(const CoarsenedGraphView &baseView,
 count CoarsenedGraphView::numberOfEdges() const {
     count edges = 0;
     for (node u = 0; u < numberOfNodes(); ++u) {
-        const auto &neighbors = getNeighbors(u);
+        const auto neighbors = computeNeighbors(u);
         for (const auto &entry : neighbors) {
             if (u <= entry.first) { // Count each edge only once
                 edges++;
@@ -72,52 +72,20 @@ count CoarsenedGraphView::numberOfEdges() const {
 count CoarsenedGraphView::degree(node supernode) const {
     if (!hasNode(supernode))
         return 0;
-    return getNeighbors(supernode).size();
+    return computeNeighbors(supernode).size();
 }
 
-edgeweight CoarsenedGraphView::weightedDegree(node supernode, bool countSelfLoopsTwice) const {
-    if (!hasNode(supernode))
-        return 0.0;
-
-    const auto &neighbors = getNeighbors(supernode);
-
-    edgeweight totalWeight = 0.0;
-    for (const auto &entry : neighbors) {
-        if (entry.first == supernode) {
-            if (countSelfLoopsTwice) {
-                totalWeight += 2 * entry.second;
+count CoarsenedGraphView::numberOfSelfLoops() const {
+    count selfLoops = 0;
+    for (node u = 0; u < numSupernodes; ++u) {
+        for (const auto &entry : computeNeighbors(u)) {
+            if (entry.first == u) { // aggregated entries carry positive weight only
+                ++selfLoops;
+                break;
             }
-        } else {
-            totalWeight += entry.second;
         }
     }
-    return totalWeight;
-}
-
-bool CoarsenedGraphView::hasEdge(node u, node v) const {
-    if (!hasNode(u) || !hasNode(v))
-        return false;
-
-    const auto &neighbors = getNeighbors(u);
-    for (const auto &entry : neighbors) {
-        if (entry.first == v) {
-            return true;
-        }
-    }
-    return false;
-}
-
-edgeweight CoarsenedGraphView::weight(node u, node v) const {
-    if (!hasNode(u) || !hasNode(v))
-        return 0.0;
-
-    const auto &neighbors = getNeighbors(u);
-    for (const auto &entry : neighbors) {
-        if (entry.first == v) {
-            return entry.second;
-        }
-    }
-    return 0.0;
+    return selfLoops;
 }
 
 const std::vector<node> &CoarsenedGraphView::getOriginalNodes(node supernode) const {
@@ -138,6 +106,13 @@ CoarsenedGraphView::computeNeighbors(node supernode) const {
         // Iterate through neighbors of each original node
         originalGraph.forNeighborsOf(originalNode, [&](node originalNeighbor, edgeweight weight) {
             node neighborSupernode = nodeMapping[originalNeighbor];
+            /*
+             * An undirected edge sits in the adjacency of both endpoints, so an edge inside this
+             * supernode would be aggregated twice. Count it once, from the higher endpoint,
+             * mirroring ParallelPartitionCoarsening's aggregation.
+             */
+            if (neighborSupernode == supernode && originalNode < originalNeighbor)
+                return;
             // Aggregate weights to the same supernode
             aggregatedWeights[neighborSupernode] += weight;
         });

--- a/networkit/cpp/coarsening/test/CMakeLists.txt
+++ b/networkit/cpp/coarsening/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 networkit_add_test(coarsening CoarseningGTest
     auxiliary community generators io matching)
+networkit_add_test(coarsening CoarsenedGraphViewGTest graph)
 
 networkit_add_benchmark(coarsening CoarseningBenchmark
         auxiliary community generators)

--- a/networkit/cpp/coarsening/test/CoarsenedGraphViewGTest.cpp
+++ b/networkit/cpp/coarsening/test/CoarsenedGraphViewGTest.cpp
@@ -1,0 +1,251 @@
+/*
+ * CoarsenedGraphViewGTest.cpp
+ *
+ *  Tests for the zero-copy coarsened graph view as a GraphLike type.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <tuple>
+#include <vector>
+
+#include <networkit/coarsening/CoarsenedGraphView.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphIterationOps.hpp>
+#include <networkit/graph/GraphW.hpp>
+#include <networkit/graph/InducedSubgraphView.hpp>
+#include <networkit/structures/Partition.hpp>
+
+namespace NetworKit {
+
+namespace {
+
+/// The weighted house graph with a self-loop on node 0; edge i carries weight i + 1 in the
+/// order 3-1, 1-0, 0-2, 2-1, 1-4, 4-3, 3-2, 2-4, and the self-loop carries 1.0.
+GraphW houseGraph() {
+    GraphW G(5, true, false);
+    const std::vector<std::pair<node, node>> edges{{3, 1}, {1, 0}, {0, 2}, {2, 1},
+                                                   {1, 4}, {4, 3}, {3, 2}, {2, 4}};
+    edgeweight w = 1.0;
+    for (const auto &[u, v] : edges) {
+        G.addEdge(u, v, w);
+        w += 1.0;
+    }
+    G.addEdge(0, 0);
+    return G;
+}
+
+/// Assigns @a groups[s] to supernode s.
+Partition partitionOf(count z, const std::vector<std::vector<node>> &groups) {
+    Partition p(z);
+    for (index s = 0; s < groups.size(); ++s)
+        for (const node u : groups[s])
+            p[u] = s;
+    return p;
+}
+
+std::vector<std::tuple<node, node, edgeweight>> sortedEdges(const CoarsenedGraphView &view) {
+    std::vector<std::tuple<node, node, edgeweight>> edges;
+    view.forEdges([&](node u, node v, edgeweight w) { edges.emplace_back(u, v, w); });
+    std::sort(edges.begin(), edges.end());
+    return edges;
+}
+
+} // namespace
+
+class CoarsenedGraphViewGTest : public testing::Test {
+protected:
+    GraphW base = houseGraph();
+};
+
+TEST_F(CoarsenedGraphViewGTest, testSingletonPartitionMirrorsOriginalGraph) {
+    Partition singleton(base.upperNodeIdBound());
+    singleton.allToSingletons();
+
+    CoarsenedGraphView view(base, singleton);
+
+    EXPECT_EQ(base.numberOfNodes(), view.numberOfNodes());
+    EXPECT_EQ(base.numberOfEdges(), view.numberOfEdges());
+    EXPECT_EQ(base.numberOfSelfLoops(), view.numberOfSelfLoops());
+    EXPECT_TRUE(view.isWeighted());
+    EXPECT_FALSE(view.isDirected());
+
+    base.forNodes([&](node u) {
+        ASSERT_EQ(base.degree(u), view.degree(u));
+        ASSERT_EQ(base.weightedDegree(u), view.weightedDegree(u));
+        std::vector<std::pair<node, edgeweight>> expected;
+        base.forEdgesOf(u, [&](node v, edgeweight w) { expected.push_back({v, w}); });
+        std::sort(expected.begin(), expected.end());
+        std::vector<std::pair<node, edgeweight>> got(view.outNeighbors<true>(u));
+        std::sort(got.begin(), got.end());
+        ASSERT_EQ(expected, got) << "supernode " << u;
+    });
+}
+
+TEST_F(CoarsenedGraphViewGTest, testAggregatedWeightsDegreesAndLoops) {
+    // {0,1} -> A, {2,3} -> B, {4} -> C
+    CoarsenedGraphView view(base, partitionOf(5, {{0, 1}, {2, 3}, {4}}));
+
+    ASSERT_EQ(3u, view.numberOfNodes());
+    ASSERT_EQ(3u, view.upperNodeIdBound());
+
+    // A={0,1}, B={2,3}, C={4}: A-B collects (3,1)+(0,2)+(2,1) = 1+3+4 = 8; the internal blocks
+    // A-A (edge 1-0 plus the self-loop) and B-B (edge 3-2) are each counted once.
+    EXPECT_EQ(5u, view.numberOfEdges()); // A-B, A-C, B-C, and the two internal blocks
+    EXPECT_EQ(2u, view.numberOfSelfLoops());
+
+    EXPECT_TRUE(view.hasEdge(0, 1)); // A-B
+    EXPECT_TRUE(view.hasEdge(0, 2)); // A-C
+    EXPECT_TRUE(view.hasEdge(1, 2)); // B-C
+    EXPECT_TRUE(view.hasEdge(0, 0)); // A-A
+    EXPECT_TRUE(view.hasEdge(1, 1)); // B-B
+
+    EXPECT_DOUBLE_EQ(8.0, view.weight(0, 1));
+    EXPECT_DOUBLE_EQ(5.0, view.weight(0, 2));  // (1,4)
+    EXPECT_DOUBLE_EQ(14.0, view.weight(1, 2)); // (4,3) + (2,4)
+    EXPECT_DOUBLE_EQ(3.0, view.weight(0, 0));  // edge 1-0 (2.0) + self-loop (1.0)
+    EXPECT_DOUBLE_EQ(7.0, view.weight(1, 1));  // edge 3-2
+
+    EXPECT_EQ(3u, view.degree(0));
+    EXPECT_EQ(3u, view.degree(1));
+    EXPECT_EQ(2u, view.degree(2));
+
+    EXPECT_DOUBLE_EQ(16.0, view.weightedDegree(0));
+    EXPECT_DOUBLE_EQ(19.0, view.weightedDegree(0, true)); // the 3.0 loop block counted twice
+    EXPECT_DOUBLE_EQ(37.0, view.totalEdgeWeight());
+
+    // every reported edge exists in both directions on the undirected view
+    view.forEdges([&](node u, node v, edgeweight w) {
+        ASSERT_TRUE(view.hasEdge(u, v));
+        ASSERT_DOUBLE_EQ(w, view.weight(u, v));
+        ASSERT_DOUBLE_EQ(w, view.weight(v, u));
+    });
+}
+
+TEST_F(CoarsenedGraphViewGTest, testLayeredCoarseningEqualsComposedPartition) {
+    const auto first = partitionOf(5, {{0, 1}, {2, 3}, {4}});
+    CoarsenedGraphView layer1(base, first);
+
+    // {A,B} -> X, {C} -> Y
+    const auto second = partitionOf(layer1.numberOfNodes(), {{0, 1}, {2}});
+    CoarsenedGraphView layer2(layer1, second);
+
+    // coarsening the original graph directly with the composed partition {0,1,2,3}, {4}
+    CoarsenedGraphView direct(base, partitionOf(5, {{0, 1, 2, 3}, {4}}));
+
+    EXPECT_EQ(direct.numberOfNodes(), layer2.numberOfNodes());
+    EXPECT_EQ(direct.numberOfEdges(), layer2.numberOfEdges());
+    EXPECT_EQ(direct.numberOfSelfLoops(), layer2.numberOfSelfLoops());
+    EXPECT_EQ(sortedEdges(direct), sortedEdges(layer2));
+
+    // X-Y collects A-C (5.0) and B-C (14.0); X-X collects A-B (8.0) and both internal blocks
+    EXPECT_DOUBLE_EQ(19.0, layer2.weight(0, 1));
+    EXPECT_DOUBLE_EQ(18.0, layer2.weight(0, 0));
+    EXPECT_EQ(1u, layer2.numberOfSelfLoops());
+}
+
+TEST_F(CoarsenedGraphViewGTest, testFreeOperationsOverView) {
+    CoarsenedGraphView view(base, partitionOf(5, {{0, 1}, {2, 3}, {4}}));
+
+    namespace Ops = GraphIterationOps;
+
+    static_assert(GraphLike<CoarsenedGraphView>);
+
+    count nodes = 0;
+    Ops::forNodes(view, [&](node) { ++nodes; });
+    EXPECT_EQ(3u, nodes);
+
+    count edges = 0;
+    Ops::forEdges(view, [&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(view.hasEdge(u, v));
+        EXPECT_GT(w, 0.0);
+        ++edges;
+    });
+    EXPECT_EQ(5u, edges);
+
+    edgeweight sum = 0.0;
+    Ops::forEdges(view, [&](node, node, edgeweight w) { sum += w; });
+    EXPECT_DOUBLE_EQ(37.0, sum);
+    EXPECT_DOUBLE_EQ(37.0, Ops::totalEdgeWeight(view));
+
+    // node ids are dense, so the free layer skips hasNode checks
+    EXPECT_TRUE(hasContiguousNodeIds(view));
+
+    EXPECT_NO_THROW(Ops::parallelForNodes(view, [](node) {}));
+    EXPECT_NO_THROW(Ops::parallelForEdges(view, [](node, node) {}));
+    EXPECT_NO_THROW(Ops::forNodesInRandomOrder(view, [](node) {}));
+    EXPECT_DOUBLE_EQ(3.0, Ops::parallelSumForNodes(view, [](node) { return 1.0; }));
+    EXPECT_DOUBLE_EQ(5.0,
+                     Ops::parallelSumForEdges(view, [](node, node, edgeweight) { return 1.0; }));
+
+    // in-neighbors are the out-neighbors on the undirected view
+    std::vector<node> inOf0;
+    Ops::forInNeighborsOf(view, 0, [&](node v) { inOf0.push_back(v); });
+    EXPECT_EQ(3u, inOf0.size());
+}
+
+TEST_F(CoarsenedGraphViewGTest, testInducedViewOverCoarsenedView) {
+    CoarsenedGraphView coarsened(base, partitionOf(5, {{0, 1}, {2, 3}, {4}}));
+
+    // keep the supernodes A (0) and C (2): the A-A loop block and A-C survive
+    InducedSubgraphView<CoarsenedGraphView> induced(coarsened, {0, 2});
+
+    static_assert(GraphLike<InducedSubgraphView<CoarsenedGraphView>>);
+
+    EXPECT_EQ(2u, induced.numberOfNodes());
+    EXPECT_EQ(2u, induced.numberOfEdges()); // A-A and A-C
+    EXPECT_EQ(1u, induced.numberOfSelfLoops());
+    EXPECT_DOUBLE_EQ(3.0, induced.weight(0, 0));
+    EXPECT_DOUBLE_EQ(5.0, induced.weight(0, 2));
+    EXPECT_EQ(2u, induced.degree(0));
+
+    count edges = 0;
+    induced.forEdges([&](node, node, edgeweight) { ++edges; });
+    EXPECT_EQ(2u, edges);
+}
+
+TEST_F(CoarsenedGraphViewGTest, testPartitionWithGapsIsCompacted) {
+    Partition p(5);
+    p[0] = 7;
+    p[1] = 7;
+    p[2] = 3;
+    p[3] = 3;
+    p[4] = 3; // ids 3 and 7 with a gap; supernode 2 unused
+
+    // compact() renumbers by sorted id order: {2,3,4} -> 0, {0,1} -> 1
+    CoarsenedGraphView view(base, p);
+    EXPECT_EQ(2u, view.numberOfNodes());
+    EXPECT_TRUE(view.hasNode(0));
+    EXPECT_TRUE(view.hasNode(1));
+    EXPECT_FALSE(view.hasNode(2));
+
+    EXPECT_EQ(3u, view.numberOfEdges()); // 0-1 crossing, plus the loop blocks on both sides
+    EXPECT_EQ(2u, view.numberOfSelfLoops());
+
+    EXPECT_DOUBLE_EQ(13.0, view.weight(0, 1)); // edges 3-1 + 0-2 + 2-1 + 1-4
+    EXPECT_DOUBLE_EQ(21.0, view.weight(0, 0)); // edges inside {2,3,4}
+    EXPECT_DOUBLE_EQ(3.0, view.weight(1, 1));  // edge 1-0 plus the self-loop inside {0,1}
+    EXPECT_EQ(2u, view.degree(0));
+    EXPECT_EQ(2u, view.degree(1));
+}
+
+TEST_F(CoarsenedGraphViewGTest, testNodeMappingAccessors) {
+    const auto p = partitionOf(5, {{0, 1}, {2, 3}, {4}});
+    CoarsenedGraphView view(base, p);
+
+    const auto &mapping = view.getNodeMapping();
+    EXPECT_EQ(0u, mapping[0]);
+    EXPECT_EQ(0u, mapping[1]);
+    EXPECT_EQ(1u, mapping[2]);
+    EXPECT_EQ(1u, mapping[3]);
+    EXPECT_EQ(2u, mapping[4]);
+
+    const auto &members = view.getOriginalNodes(0);
+    EXPECT_EQ(std::vector<node>({0, 1}), members);
+
+    EXPECT_EQ(std::vector<node>(), view.getOriginalNodes(42));
+}
+
+} // namespace NetworKit

--- a/networkit/cpp/graph/test/CMakeLists.txt
+++ b/networkit/cpp/graph/test/CMakeLists.txt
@@ -2,6 +2,7 @@ networkit_add_test(graph GraphArchetypeGTest)
 networkit_add_test(graph GraphBuilderAutoCompleteGTest auxiliary)
 networkit_add_test(graph GraphGTest
     auxiliary dyn_distance io generators)
+networkit_add_test(graph InducedSubgraphViewGTest)
 networkit_add_test(graph GraphWGTest
     auxiliary dyn_distance io generators)
 networkit_add_test(graph GraphToolsGTest generators io)

--- a/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
+++ b/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
@@ -193,8 +193,13 @@ TEST_F(InducedSubgraphViewGTest, testUnknownNodeThrows) {
     InducedSubgraphView<GraphW> view(base);
     EXPECT_THROW(view.addNode(base.upperNodeIdBound()), std::runtime_error);
     EXPECT_THROW(view.addNodes({0, 99}), std::runtime_error);
-    // removal of unknown ids is a no-op, not an error
+    // removal of unknown ids is a no-op, not an error -- including ids beyond the base's id
+    // space, which must not touch the presence/degree storage (regression: OOB write)
     EXPECT_NO_THROW(view.removeNode(99));
+    EXPECT_NO_THROW(view.removeNodes({99, base.upperNodeIdBound() + 100}));
+    // the failed batch left node 0 inserted; removal of unknown ids changed nothing else
+    EXPECT_EQ(1u, view.numberOfNodes());
+    EXPECT_TRUE(view.hasNode(0));
 }
 
 TEST_F(InducedSubgraphViewGTest, testInNeighborsOnUndirectedBase) {

--- a/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
+++ b/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
@@ -413,4 +413,46 @@ TEST_F(InducedSubgraphViewGTest, testRandomizedAgainstGroundTruth) {
     }
 }
 
+TEST_F(InducedSubgraphViewGTest, testAdaptiveHubNeighborhoods) {
+    // A star: node 0 with 200 leaves. The view keeps the hub and three of its leaves, so
+    // deg_base(0) = 200 overshoots n_view * bit_width(200) * 4 = 4 * 8 * 4 = 128: both the
+    // out- and the in-neighborhood ranges must take the subset-scanning strategy, which walks
+    // members ascending rather than scanning all 200 base neighbors.
+    GraphW star(201, true, false);
+    for (node leaf = 1; leaf <= 200; ++leaf)
+        star.addEdge(0, leaf, static_cast<edgeweight>(leaf));
+
+    const std::set<node> subset{0, 5, 100, 200};
+    InducedSubgraphView<GraphW> view(star, subset);
+    ASSERT_EQ(3u, view.numberOfEdges());
+
+    std::vector<node> plain;
+    for (const auto v : view.outNeighbors<false>(0))
+        plain.push_back(v);
+    EXPECT_EQ((std::vector<node>{5, 100, 200}), plain); // ascending: subset-scan order
+
+    std::vector<std::pair<node, edgeweight>> weighted;
+    for (const auto &nb : view.outNeighbors<true>(0))
+        weighted.push_back(nb);
+    EXPECT_EQ(3u, weighted.size());
+    for (const auto &[v, w] : weighted) {
+        EXPECT_EQ(w, static_cast<edgeweight>(v)); // weights carried through either strategy
+    }
+
+    // undirected base: in-neighbors agree with out-neighbors
+    std::vector<node> incoming;
+    view.forInNeighborsOf(0, [&](node v) { incoming.push_back(v); });
+    EXPECT_EQ((std::vector<node>{5, 100, 200}), incoming);
+
+    // a big view over the same hub stays on the base scan and must produce identical members
+    std::set<node> wide{0};
+    for (node leaf = 1; leaf <= 150; ++leaf)
+        wide.insert(leaf);
+    InducedSubgraphView<GraphW> wideView(star, wide);
+    std::vector<node> fromWide;
+    wideView.forNeighborsOf(0, [&](node v) { fromWide.push_back(v); });
+    ASSERT_EQ(150u, fromWide.size()); // every kept leaf
+    EXPECT_TRUE(std::is_sorted(fromWide.begin(), fromWide.end()));
+}
+
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
+++ b/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
@@ -475,6 +475,33 @@ TEST_F(InducedSubgraphViewGTest, testHandleRunsExistingAlgorithms) {
         EXPECT_EQ(referenceKcore.score(u), kcore.score(u)) << "node " << u;
 }
 
+/*
+ * The conversion hands out the handle embedded inside the view: one address per view, stable
+ * across statements -- which is what makes "construct an algorithm, then run it" sound rather
+ * than merely lucky -- and re-seated when the view is copied, so a copy never aliases the
+ * original's handle.
+ */
+TEST_F(InducedSubgraphViewGTest, testHandleIsEmbeddedAndIdentityBound) {
+    const std::set<node> subset{1, 2, 3, 4};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    const ReferenceGraph &borrowed = view;
+    EXPECT_EQ(&borrowed, &view.asGraph());
+
+    GraphW reference = GraphTools::subgraphFromNodes(base, subset.begin(), subset.end(), false);
+    CoreDecomposition expected(reference);
+    expected.run();
+    CoreDecomposition kcore(borrowed); // stored across statements by the algorithm class
+    kcore.run();
+    for (const node u : subset)
+        EXPECT_EQ(expected.score(u), kcore.score(u)) << "node " << u;
+
+    InducedSubgraphView<GraphW> copy = view;
+    const ReferenceGraph &copiedHandle = copy;
+    EXPECT_NE(&copiedHandle, &borrowed); // identity-bound: the copy carries its own handle
+    EXPECT_EQ(borrowed.numberOfEdges(), copiedHandle.numberOfEdges());
+}
+
 TEST_F(InducedSubgraphViewGTest, testHandleSurfaceOverViewArms) {
     const std::set<node> subset{1, 2, 3, 4};
     InducedSubgraphView<GraphW> wView(base, subset);

--- a/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
+++ b/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
@@ -14,6 +14,7 @@
 
 #include <networkit/auxiliary/Random.hpp>
 #include <networkit/auxiliary/Vector2Arrow.hpp>
+#include <networkit/centrality/CoreDecomposition.hpp>
 #include <networkit/generators/ErdosRenyiGenerator.hpp>
 #include <networkit/graph/Graph.hpp>
 #include <networkit/graph/GraphIterationOps.hpp>
@@ -453,6 +454,81 @@ TEST_F(InducedSubgraphViewGTest, testAdaptiveHubNeighborhoods) {
     wideView.forNeighborsOf(0, [&](node v) { fromWide.push_back(v); });
     ASSERT_EQ(150u, fromWide.size()); // every kept leaf
     EXPECT_TRUE(std::is_sorted(fromWide.begin(), fromWide.end()));
+}
+
+/*
+ * The type-erased handle accepts the two view instantiations as arms, so an unmodified algorithm
+ * -- here CoreDecomposition, the case Ian asked to compile unchanged -- consumes a view directly.
+ */
+TEST_F(InducedSubgraphViewGTest, testHandleRunsExistingAlgorithms) {
+    const std::set<node> subset{1, 2, 3, 4};
+    InducedSubgraphView<GraphW> view(base, subset);
+    GraphW reference = GraphTools::subgraphFromNodes(base, subset.begin(), subset.end(), false);
+
+    // Implicit handle conversion at the call site; no copy of the view, no wrapper type.
+    CoreDecomposition kcore(view);
+    kcore.run();
+    CoreDecomposition referenceKcore(reference);
+    referenceKcore.run();
+
+    for (const node u : subset)
+        EXPECT_EQ(referenceKcore.score(u), kcore.score(u)) << "node " << u;
+}
+
+TEST_F(InducedSubgraphViewGTest, testHandleSurfaceOverViewArms) {
+    const std::set<node> subset{1, 2, 3, 4};
+    InducedSubgraphView<GraphW> wView(base, subset);
+    const ReferenceGraph &h = wView; // implicit, same conversion the algorithms take
+
+    EXPECT_EQ(4u, h.numberOfNodes());
+    EXPECT_EQ(6u, h.numberOfEdges()); // every base edge with both endpoints kept
+    EXPECT_EQ(0u, h.numberOfSelfLoops());
+    EXPECT_EQ(5u, h.upperNodeIdBound());
+    EXPECT_FALSE(h.hasNode(0));
+    EXPECT_TRUE(h.hasEdge(1, 2));
+    EXPECT_FALSE(h.hasEdge(0, 1));
+    EXPECT_EQ(3u, h.degree(1));
+    EXPECT_TRUE(h.isWeighted());
+    EXPECT_FALSE(h.hasEdgeIds());
+    EXPECT_TRUE(h.checkConsistency());
+    EXPECT_DOUBLE_EQ(1.0 + 4.0 + 5.0 + 6.0 + 7.0 + 8.0, h.totalEdgeWeight());
+
+    // indexed access follows the base adjacency order of each row, filtered to the members
+    EXPECT_EQ(3u, h.getIthNeighbor(1, 0));
+    EXPECT_EQ(none, h.getIthNeighbor(1, 3));
+    EXPECT_DOUBLE_EQ(4.0, h.getIthNeighborWeight(1, 1));
+    EXPECT_EQ(0u, h.indexOfNeighbor(2, 1));
+
+    // erased neighbor ranges agree with the view's own
+    count seen = 0;
+    h.forNeighborsOf(4, [&](node v) {
+        EXPECT_TRUE(wView.hasNode(v));
+        ++seen;
+    });
+    EXPECT_EQ(3u, seen);
+
+    count edgeCount = 0;
+    edgeweight weightSum = 0.0;
+    h.forEdges([&](node, node, edgeweight w) {
+        ++edgeCount;
+        weightSum += w;
+    });
+    EXPECT_EQ(6u, edgeCount);
+    EXPECT_DOUBLE_EQ(h.totalEdgeWeight(), weightSum);
+
+    // capabilities the views deliberately do not carry
+    EXPECT_THROW(h.edgeId(1, 2), std::runtime_error);
+    EXPECT_THROW((void)h.nodeAttributes(), std::runtime_error);
+
+    // the same surface over a CSR base
+    const GraphR R = houseCSR();
+    InducedSubgraphView<GraphR> rView(R, {2});
+    const ReferenceGraph &rh = rView;
+    EXPECT_EQ(1u, rh.numberOfNodes());
+    EXPECT_EQ(0u, rh.numberOfEdges());
+    EXPECT_EQ(0u, rh.degree(2));
+    EXPECT_TRUE(rh.checkConsistency());
+    EXPECT_THROW(rh.edgeById(0), std::runtime_error);
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
+++ b/networkit/cpp/graph/test/InducedSubgraphViewGTest.cpp
@@ -1,0 +1,411 @@
+/*
+ * InducedSubgraphViewGTest.cpp
+ *
+ *  Tests for the zero-copy induced subgraph view over GraphLike bases.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
+#include <networkit/auxiliary/Random.hpp>
+#include <networkit/auxiliary/Vector2Arrow.hpp>
+#include <networkit/generators/ErdosRenyiGenerator.hpp>
+#include <networkit/graph/Graph.hpp>
+#include <networkit/graph/GraphIterationOps.hpp>
+#include <networkit/graph/GraphR.hpp>
+#include <networkit/graph/GraphTools.hpp>
+#include <networkit/graph/GraphW.hpp>
+#include <networkit/graph/InducedSubgraphView.hpp>
+
+namespace NetworKit {
+
+namespace {
+
+/// A fixed house graph plus a self-loop on node 0:
+/// edges 3-1, 1-0, 0-2, 2-1, 1-4, 4-3, 3-2, 2-4, in that insertion order.
+GraphW houseBase(bool weighted = true) {
+    const count n = 5;
+    GraphW G(n, weighted, false);
+    std::vector<std::pair<node, node>> edges{{3, 1}, {1, 0}, {0, 2}, {2, 1},
+                                             {1, 4}, {4, 3}, {3, 2}, {2, 4}};
+    edgeweight w = 1.0;
+    for (const auto &[u, v] : edges) {
+        G.addEdge(u, v, w);
+        if (weighted)
+            w += 1.0;
+    }
+    G.addEdge(0, 0); // self-loop
+    return G;
+}
+
+/// A fixed unweighted undirected GraphR: the house graph without the self-loop, CSR-encoded.
+GraphR houseCSR() {
+    const std::vector<std::vector<node>> adjacency{
+        {1, 2}, {0, 2, 3, 4}, {0, 1, 3, 4}, {1, 2, 4}, {1, 2, 3}};
+    std::vector<uint64_t> indptr{0};
+    std::vector<uint64_t> indices;
+    for (const auto &neighbors : adjacency) {
+        indices.insert(indices.end(), neighbors.begin(), neighbors.end());
+        indptr.push_back(indices.size());
+    }
+
+    // An undirected GraphR shares the out arrays with the in arrays.
+    return GraphR(5, false, Aux::vectorToArrow<uint64_t, arrow::UInt64Array>(std::move(indices)),
+                  Aux::vectorToArrow<uint64_t, arrow::UInt64Array>(std::move(indptr)));
+}
+
+/// The induced edge set of @a G on @a subset, computed independently of the view.
+std::vector<std::tuple<node, node, edgeweight>> expectedEdges(const GraphW &G,
+                                                              const std::set<node> &subset) {
+    std::vector<std::tuple<node, node, edgeweight>> result;
+    for (const node u : subset)
+        G.forNeighborsOf(u, [&](node v, edgeweight w) {
+            if (!subset.count(v))
+                return;
+            if (!G.isDirected() && u > v)
+                return;
+            result.emplace_back(u, v, w);
+        });
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+template <typename View>
+void expectSameEdges(const GraphW &G, const std::set<node> &subset, const View &view) {
+    using Entry = std::tuple<node, node, edgeweight>;
+    std::vector<Entry> viewEdges;
+    view.forEdges([&](node u, node v, edgeweight w) { viewEdges.emplace_back(u, v, w); });
+    std::sort(viewEdges.begin(), viewEdges.end());
+    EXPECT_EQ(expectedEdges(G, subset), viewEdges);
+}
+
+} // namespace
+
+class InducedSubgraphViewGTest : public testing::Test {
+protected:
+    GraphW base = houseBase();
+};
+
+TEST_F(InducedSubgraphViewGTest, testConstructionFromSubset) {
+    const std::set<node> subset{0, 1, 2, 4};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    EXPECT_EQ(4u, view.numberOfNodes());
+    EXPECT_EQ(base.upperNodeIdBound(), view.upperNodeIdBound());
+    EXPECT_TRUE(view.isWeighted());
+    EXPECT_FALSE(view.isDirected());
+
+    // house edges among {0,1,2,4}: 1-0, 0-2, 2-1, 1-4, 2-4 -- plus the self-loop
+    EXPECT_EQ(6u, view.numberOfEdges());
+    EXPECT_EQ(1u, view.numberOfSelfLoops());
+
+    for (const node u : subset)
+        ASSERT_TRUE(view.hasNode(u));
+    EXPECT_FALSE(view.hasNode(3));
+    EXPECT_FALSE(view.hasNode(base.upperNodeIdBound()));
+}
+
+TEST_F(InducedSubgraphViewGTest, testDegreesMatchFilteredNeighborhoods) {
+    const std::set<node> subset{1, 2, 3};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    // induced house edges among {1,2,3}: 3-1, 2-1, 3-2 -- a triangle, no self-loops
+    EXPECT_EQ(3u, view.numberOfEdges());
+    EXPECT_EQ(0u, view.numberOfSelfLoops());
+    EXPECT_EQ(2u, view.degree(1));
+    EXPECT_EQ(2u, view.degree(2));
+    EXPECT_EQ(2u, view.degree(3));
+
+    count seen = 0;
+    view.forNodes([&](node u) {
+        count neighbors = 0;
+        view.forNeighborsOf(u, [&](node) { ++neighbors; });
+        ASSERT_EQ(view.degree(u), neighbors);
+        ++seen;
+    });
+    EXPECT_EQ(3u, seen);
+}
+
+TEST_F(InducedSubgraphViewGTest, testNeighborhoodsCarryWeights) {
+    const std::set<node> subset{0, 1, 2};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    std::vector<std::pair<node, edgeweight>> out0;
+    for (const auto nb : view.outNeighbors<true>(0))
+        out0.push_back(nb);
+    std::sort(out0.begin(), out0.end());
+
+    // base weights around 0: self-loop 1.0, 1-0 has 2.0, 0-2 has 3.0
+    ASSERT_EQ(3u, out0.size());
+    EXPECT_EQ(0u, out0[0].first);
+    EXPECT_DOUBLE_EQ(1.0, out0[0].second);
+    EXPECT_EQ(1u, out0[1].first);
+    EXPECT_DOUBLE_EQ(2.0, out0[1].second);
+    EXPECT_EQ(2u, out0[2].first);
+    EXPECT_DOUBLE_EQ(3.0, out0[2].second);
+
+    // unweighted payload yields bare targets: 0's in-subject neighbors are its self-loop, 1, 2
+    std::vector<node> plain;
+    for (const auto v : view.outNeighbors<false>(0))
+        plain.push_back(v);
+    std::sort(plain.begin(), plain.end());
+    EXPECT_EQ(std::vector<node>({0, 1, 2}), plain);
+}
+
+TEST_F(InducedSubgraphViewGTest, testBatchAddAndRemoveKeepsCountersConsistent) {
+    InducedSubgraphView<GraphW> view(base);
+    EXPECT_EQ(0u, view.numberOfNodes());
+    EXPECT_EQ(0u, view.numberOfEdges());
+
+    // adding {0..4} one by one must reproduce the whole base graph
+    for (node u = 0; u < base.upperNodeIdBound(); ++u)
+        view.addNode(u);
+
+    ASSERT_EQ(base.numberOfNodes(), view.numberOfNodes());
+    ASSERT_EQ(base.numberOfEdges(), view.numberOfEdges());
+    ASSERT_EQ(base.numberOfSelfLoops(), view.numberOfSelfLoops());
+    expectSameEdges(base, {0, 1, 2, 3, 4}, view);
+
+    // batch removal, including an id that is already gone
+    view.removeNodes({0, 2, 4});
+    view.removeNode(4);
+    const std::set<node> subset{1, 3};
+    ASSERT_EQ(subset.size(), view.numberOfNodes());
+    ASSERT_EQ(1u, view.numberOfEdges()); // 3-1
+    ASSERT_EQ(0u, view.numberOfSelfLoops());
+    expectSameEdges(base, subset, view);
+
+    // growing back in one batch, order shuffled, duplicate included
+    view.addNodes({4, 0, 2, 4});
+    const std::set<node> regrown{0, 1, 2, 3, 4};
+    ASSERT_EQ(regrown.size(), view.numberOfNodes());
+    ASSERT_EQ(base.numberOfEdges(), view.numberOfEdges());
+    ASSERT_EQ(base.numberOfSelfLoops(), view.numberOfSelfLoops());
+    expectSameEdges(base, regrown, view);
+}
+
+TEST_F(InducedSubgraphViewGTest, testUnknownNodeThrows) {
+    InducedSubgraphView<GraphW> view(base);
+    EXPECT_THROW(view.addNode(base.upperNodeIdBound()), std::runtime_error);
+    EXPECT_THROW(view.addNodes({0, 99}), std::runtime_error);
+    // removal of unknown ids is a no-op, not an error
+    EXPECT_NO_THROW(view.removeNode(99));
+}
+
+TEST_F(InducedSubgraphViewGTest, testInNeighborsOnUndirectedBase) {
+    const std::set<node> subset{1, 3, 4};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    std::vector<node> inOf1;
+    for (const auto nb : view.inNeighbors<false>(1))
+        inOf1.push_back(neighborTarget(nb)); // 3 and 4 stay; 0 and 2 are filtered out
+    EXPECT_EQ(std::vector<node>({3, 4}), inOf1);
+}
+
+TEST(InducedSubgraphViewDirectedGTest, testDirectedCountersAndRanges) {
+    GraphW D(4, true, true);
+    D.addEdge(0, 1, 1.0);
+    D.addEdge(1, 2, 2.0);
+    D.addEdge(2, 1, 3.0);
+    D.addEdge(3, 3, 4.0); // directed self-loop
+    D.addEdge(3, 0, 5.0);
+
+    using Entry = std::tuple<node, node, edgeweight>;
+    std::vector<Entry> expected;
+    D.forEdges([&](node u, node v, edgeweight w) { expected.emplace_back(u, v, w); });
+
+    const std::set<node> subset{0, 1, 2, 3};
+    InducedSubgraphView<GraphW> view(D, subset);
+
+    std::vector<Entry> got;
+    view.forEdges([&](node u, node v, edgeweight w) { got.emplace_back(u, v, w); });
+    std::sort(got.begin(), got.end());
+    EXPECT_EQ(expected.size(), got.size());
+
+    // in-arcs of 1: 0->1 and 2->1; out-arcs: 1->2
+    EXPECT_EQ(2u, view.degreeIn(1));
+    EXPECT_EQ(1u, view.degreeOut(1));
+    EXPECT_EQ(1u, view.degreeIn(3));
+    EXPECT_EQ(2u, view.degreeOut(3));
+    EXPECT_EQ(1u, view.numberOfSelfLoops());
+
+    // shrink to {1, 2}: only the 1 <-> 2 pair survives, self-loop and both cross arcs vanish
+    view.removeNodes({0, 3});
+    EXPECT_EQ(2u, view.numberOfNodes());
+    EXPECT_EQ(2u, view.numberOfEdges());
+    EXPECT_EQ(0u, view.numberOfSelfLoops());
+    EXPECT_EQ(1u, view.degreeIn(1));
+    EXPECT_EQ(1u, view.degreeOut(1));
+    EXPECT_EQ(1u, view.degreeIn(2));
+    EXPECT_EQ(1u, view.degreeOut(2));
+    EXPECT_DOUBLE_EQ(2.0, view.weight(1, 2));
+    EXPECT_DOUBLE_EQ(3.0, view.weight(2, 1));
+}
+
+TEST_F(InducedSubgraphViewGTest, testFrontier) {
+    const std::set<node> subset{0, 1};
+    InducedSubgraphView<GraphW> view(base, subset);
+    // out-neighbors outside {0,1}: 0 reaches 2; 1 reaches 2, 3 and 4
+    const auto f = view.frontier();
+    const std::set<node> expected(f.begin(), f.end());
+    EXPECT_EQ(std::set<node>({2, 3, 4}), expected);
+    EXPECT_TRUE(std::is_sorted(f.begin(), f.end()));
+
+    view.addNodes({2, 3, 4});
+    EXPECT_TRUE(view.frontier().empty());
+}
+
+TEST_F(InducedSubgraphViewGTest, testRealizeMatchesSubgraphFromNodes) {
+    const std::set<node> subset{0, 1, 3, 4};
+
+    InducedSubgraphView<GraphW> view(base, subset);
+    GraphW realizedKeep = view.realize(false);
+    GraphW referenceKeep = GraphTools::subgraphFromNodes(base, subset.begin(), subset.end(), false);
+    EXPECT_EQ(referenceKeep.numberOfNodes(), realizedKeep.numberOfNodes());
+    EXPECT_EQ(referenceKeep.numberOfEdges(), realizedKeep.numberOfEdges());
+    EXPECT_EQ(referenceKeep.numberOfSelfLoops(), realizedKeep.numberOfSelfLoops());
+    EXPECT_EQ(referenceKeep.totalEdgeWeight(), realizedKeep.totalEdgeWeight());
+
+    GraphW realizedCompact = view.realize(true);
+    GraphW referenceCompact =
+        GraphTools::subgraphFromNodes(base, subset.begin(), subset.end(), true);
+    EXPECT_EQ(referenceCompact.numberOfNodes(), realizedCompact.numberOfNodes());
+    EXPECT_EQ(referenceCompact.numberOfEdges(), realizedCompact.numberOfEdges());
+    EXPECT_EQ(4u, realizedCompact.upperNodeIdBound());
+    EXPECT_EQ(referenceCompact.totalEdgeWeight(), realizedCompact.totalEdgeWeight());
+
+    // compact ids are dense
+    count visited = 0;
+    realizedCompact.forNodes([&](node) { ++visited; });
+    EXPECT_EQ(realizedCompact.numberOfNodes(), visited);
+    EXPECT_EQ(realizedCompact.upperNodeIdBound(), visited);
+}
+
+TEST_F(InducedSubgraphViewGTest, testFreeOperationsOverView) {
+    const std::set<node> subset{1, 2, 3, 4};
+    InducedSubgraphView<GraphW> view(base, subset);
+
+    namespace Ops = GraphIterationOps;
+
+    count nodes = 0;
+    Ops::forNodes(view, [&](node) { ++nodes; });
+    EXPECT_EQ(4u, nodes);
+
+    count edges = 0;
+    Ops::forEdges(view, [&](node u, node v, edgeweight w) {
+        EXPECT_TRUE(view.hasEdge(u, v));
+        EXPECT_GT(w, 0.0);
+        ++edges;
+    });
+    EXPECT_EQ(view.numberOfEdges(), edges);
+
+    // weighted degree sums over the filtered neighborhood
+    view.forNodes([&](node u) {
+        edgeweight sum = 0.0;
+        view.forEdgesOf(u, [&](node, edgeweight w) { sum += w; });
+        EXPECT_DOUBLE_EQ(sum, view.weightedDegree(u));
+    });
+
+    edgeweight total = 0.0;
+    view.forEdges([&](node, node, edgeweight w) { total += w; });
+    EXPECT_DOUBLE_EQ(total, view.totalEdgeWeight());
+
+    EXPECT_FALSE(Ops::hasEdge(view, 1, 0)) << "0 left the subset";
+    EXPECT_TRUE(Ops::hasEdge(view, 3, 2));
+    EXPECT_GT(Ops::weight(view, 3, 2), 0.0);
+    EXPECT_EQ(nullWeight, Ops::weight(view, 1, 0));
+
+    EXPECT_NO_THROW(Ops::parallelForEdges(view, [](node, node) {}));
+    EXPECT_NO_THROW(Ops::parallelSumForEdges(view, [](node, node, edgeweight) { return 1.0; }));
+}
+
+TEST_F(InducedSubgraphViewGTest, testViewOverViewComposes) {
+    InducedSubgraphView<GraphW> inner(base, {0, 1, 2, 3, 4});
+    inner.removeNodes({0});
+
+    static_assert(
+        GraphLike<InducedSubgraphView<InducedSubgraphView<GraphW>>>,
+        "an induced view over an induced view must itself be usable wherever a graph type is");
+
+    InducedSubgraphView<InducedSubgraphView<GraphW>> outer(inner, {1, 2, 4});
+
+    EXPECT_EQ(3u, outer.numberOfNodes());
+    expectSameEdges(base, {1, 2, 4}, outer);
+}
+
+TEST(InducedSubgraphViewOverGraphRGTest, testReadOnlyBase) {
+    GraphR R = houseCSR();
+
+    const std::set<node> subset{1, 2, 3};
+    InducedSubgraphView<GraphR> view(R, subset);
+
+    EXPECT_FALSE(view.isWeighted());
+    EXPECT_EQ(3u, view.numberOfEdges()); // the induced triangle
+    EXPECT_EQ(0u, view.numberOfSelfLoops());
+    EXPECT_EQ(defaultEdgeWeight, view.weight(1, 2));
+    EXPECT_EQ(nullWeight, view.weight(1, 4));
+
+    count edges = 0;
+    view.forEdges([&](node u, node v, edgeweight w) {
+        EXPECT_DOUBLE_EQ(defaultEdgeWeight, w);
+        ++edges;
+    });
+    EXPECT_EQ(3u, edges);
+
+    // free ops see an unweighted graph and fall back to degree-based aggregates
+    EXPECT_DOUBLE_EQ(2.0, view.weightedDegree(1));
+
+    // the base's sorted neighborhoods survive filtering, so lookups may bisect
+    EXPECT_TRUE(view.hasSortedNeighborhoods());
+}
+
+TEST_F(InducedSubgraphViewGTest, testRandomizedAgainstGroundTruth) {
+    for (int trial = 0; trial < 20; ++trial) {
+        ErdosRenyiGenerator gen(12, 0.35, trial % 2 == 1);
+        GraphW G = gen.generate();
+
+        InducedSubgraphView<GraphW> view(G);
+        std::set<node> subset;
+        for (node u = 0; u < G.upperNodeIdBound(); ++u)
+            if (Aux::Random::probability() < 0.6) {
+                view.addNode(u);
+                subset.insert(u);
+            }
+
+        ASSERT_EQ(subset.size(), view.numberOfNodes());
+
+        count mExpected = 0;
+        const bool directed = G.isDirected();
+        for (const node u : subset)
+            G.forNeighborsOf(u, [&](node v) {
+                if (!subset.count(v))
+                    return;
+                if (!directed && u > v)
+                    return;
+                ++mExpected;
+            });
+        ASSERT_EQ(mExpected, view.numberOfEdges())
+            << "trial " << trial << ": edge bookkeeping diverged";
+
+        view.forNodes([&](node u) {
+            count d = 0;
+            G.forNeighborsOf(u, [&](node v) { d += subset.count(v) ? 1 : 0; });
+            ASSERT_EQ(d, view.degree(u)) << "trial " << trial << ", node " << u;
+        });
+
+        count loops = 0;
+        for (const node u : subset)
+            if (G.hasEdge(u, u))
+                ++loops;
+        ASSERT_EQ(loops, view.numberOfSelfLoops()) << "trial " << trial;
+
+        expectSameEdges(G, subset, view);
+    }
+}
+
+} // namespace NetworKit

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -194,6 +194,44 @@ cdef extern from "<networkit/graph/GraphR.hpp>":
 		_NodeAttrMap& nodeAttributes() noexcept
 		_EdgeAttrMap& edgeAttributes() noexcept
 
+# The two instantiations the type-erased handle knows: views over the writable graph and over
+# the read-only CSR graph. Membership edits are allowed over either base.
+cdef extern from "<networkit/graph/InducedSubgraphView.hpp>":
+	cdef cppclass _InducedSubgraphViewW "NetworKit::InducedSubgraphView<NetworKit::GraphW>":
+		_InducedSubgraphViewW(const _GraphW& base) except +
+		count numberOfNodes() except +
+		count numberOfEdges() except +
+		count numberOfSelfLoops() except +
+		index upperNodeIdBound() except +
+		bool_t isDirected() except +
+		bool_t isWeighted() except +
+		bool_t hasNode(node u) except +
+		count degree(node u) except +
+		void addNodes(vector[node] nodes) except +
+		void removeNodes(vector[node] nodes) except +
+		vector[node] getNodeSubset() except +
+		_GraphW realize(bool_t compact) except +
+
+	cdef cppclass _InducedSubgraphViewR "NetworKit::InducedSubgraphView<NetworKit::GraphR>":
+		_InducedSubgraphViewR(const _GraphR& base) except +
+		count numberOfNodes() except +
+		count numberOfEdges() except +
+		count numberOfSelfLoops() except +
+		index upperNodeIdBound() except +
+		bool_t isDirected() except +
+		bool_t isWeighted() except +
+		bool_t hasNode(node u) except +
+		count degree(node u) except +
+		void addNodes(vector[node] nodes) except +
+		void removeNodes(vector[node] nodes) except +
+		vector[node] getNodeSubset() except +
+		_GraphW realize(bool_t compact) except +
+
+cdef extern from "<networkit/graph/ReferenceGraphImpl.hpp>" namespace "NetworKit":
+	# Cython cannot spell the implicit view-to-handle conversions; these give it one.
+	_Graph refGraphVW(const _InducedSubgraphViewW& g) except +
+	_Graph refGraphVR(const _InducedSubgraphViewR& g) except +
+
 cdef extern from "<networkit/graph/Graph.hpp>" namespace "NetworKit":
 	# Parameterized on the handle rather than on the concrete graph, so every arm's attribute
 	# maps have this one type. Reaching an attribute therefore never depends on which arm is
@@ -412,9 +450,12 @@ cdef class Graph:
 	cdef _NodeAttrMap *_nodeAttrs
 	cdef _EdgeAttrMap *_edgeAttrs
 	cdef _GraphW *_w  # non-NULL exactly when this graph can be written
+	cdef _GraphR *_r  # non-NULL exactly when this graph is CSR-backed
+	cdef object _base  # the viewed graph, exactly when this graph is a subgraph view
 	cdef dict _arrow_arrays
 	cdef _seatW(self, shared_ptr[_GraphW] g)
 	cdef _seatR(self, shared_ptr[_GraphR] g)
+	cdef _seatV(self, shared_ptr[_InducedSubgraphViewW] wv, shared_ptr[_InducedSubgraphViewR] rv, object base)
 	cdef const _Graph* _view(self) noexcept nogil
 	cdef _GraphW* _mutable(self) except NULL
 	cdef setThis(self, const _Graph& other)

--- a/networkit/graph.pxd
+++ b/networkit/graph.pxd
@@ -199,6 +199,7 @@ cdef extern from "<networkit/graph/GraphR.hpp>":
 cdef extern from "<networkit/graph/InducedSubgraphView.hpp>":
 	cdef cppclass _InducedSubgraphViewW "NetworKit::InducedSubgraphView<NetworKit::GraphW>":
 		_InducedSubgraphViewW(const _GraphW& base) except +
+		const _Graph& asGraph() noexcept
 		count numberOfNodes() except +
 		count numberOfEdges() except +
 		count numberOfSelfLoops() except +
@@ -214,6 +215,7 @@ cdef extern from "<networkit/graph/InducedSubgraphView.hpp>":
 
 	cdef cppclass _InducedSubgraphViewR "NetworKit::InducedSubgraphView<NetworKit::GraphR>":
 		_InducedSubgraphViewR(const _GraphR& base) except +
+		const _Graph& asGraph() noexcept
 		count numberOfNodes() except +
 		count numberOfEdges() except +
 		count numberOfSelfLoops() except +
@@ -226,11 +228,6 @@ cdef extern from "<networkit/graph/InducedSubgraphView.hpp>":
 		void removeNodes(vector[node] nodes) except +
 		vector[node] getNodeSubset() except +
 		_GraphW realize(bool_t compact) except +
-
-cdef extern from "<networkit/graph/ReferenceGraphImpl.hpp>" namespace "NetworKit":
-	# Cython cannot spell the implicit view-to-handle conversions; these give it one.
-	_Graph refGraphVW(const _InducedSubgraphViewW& g) except +
-	_Graph refGraphVR(const _InducedSubgraphViewR& g) except +
 
 cdef extern from "<networkit/graph/Graph.hpp>" namespace "NetworKit":
 	# Parameterized on the handle rather than on the concrete graph, so every arm's attribute

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -2,6 +2,7 @@
 
 from cython.operator import dereference, preincrement
 from libcpp.algorithm cimport swap
+from libcpp.vector cimport vector
 
 import numpy as np
 from scipy.sparse import coo_matrix
@@ -63,6 +64,8 @@ cdef class Graph:
 	# must go through one, or the cached pointers below describe a graph that is no longer held.
 	cdef _seatW(self, shared_ptr[_GraphW] g):
 		self._w = g.get()
+		self._r = NULL
+		self._base = None
 		self._handle = dereference(self._w).asGraph()
 		self._nodeAttrs = &dereference(self._w).nodeAttributes()
 		self._edgeAttrs = &dereference(self._w).edgeAttributes()
@@ -71,10 +74,30 @@ cdef class Graph:
 
 	cdef _seatR(self, shared_ptr[_GraphR] g):
 		self._w = NULL
+		self._r = g.get()
+		self._base = None
 		self._handle = dereference(g).asGraph()
 		self._nodeAttrs = &dereference(g).nodeAttributes()
 		self._edgeAttrs = &dereference(g).edgeAttributes()
 		self._owner = nk_erase[_GraphR](g)
+		return self
+
+	cdef _seatV(self, shared_ptr[_InducedSubgraphViewW] wv, shared_ptr[_InducedSubgraphViewR] rv,
+			object base):
+		self._w = NULL
+		self._r = NULL
+		# The view holds a bare pointer into base, so base has to outlive this seat; keeping the
+		# Python object alive keeps the C++ graph alive with it.
+		self._base = base
+		if wv:
+			self._handle = refGraphVW(dereference(wv))
+			self._owner = nk_erase[_InducedSubgraphViewW](wv)
+		else:
+			self._handle = refGraphVR(dereference(rv))
+			self._owner = nk_erase[_InducedSubgraphViewR](rv)
+		# Views carry no attribute maps of their own.
+		self._nodeAttrs = NULL
+		self._edgeAttrs = NULL
 		return self
 
 	cdef const _Graph* _view(self) noexcept nogil:
@@ -1030,6 +1053,9 @@ cdef class Graph:
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
 
+		if self._nodeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
+
 		if ofType == int:
 			return NodeAttribute(NodeIntAttribute().setThis(dereference(self._nodeAttrs).attachInt(stdstring(name))), int)
 		elif ofType == float:
@@ -1066,6 +1092,9 @@ cdef class Graph:
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
 
+		if self._nodeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
+
 		if ofType == int:
 			return NodeAttribute(NodeIntAttribute().setThis(dereference(self._nodeAttrs).getInt(stdstring(name))), int)
 		elif ofType == float:
@@ -1090,6 +1119,8 @@ cdef class Graph:
 		"""
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
+		if self._nodeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
 		dereference(self._nodeAttrs).detach(stdstring(name))
 
 	def attachEdgeAttribute(self, name, ofType):
@@ -1131,6 +1162,9 @@ cdef class Graph:
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
 
+		if self._edgeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
+
 		if ofType == int:
 			return EdgeAttribute(EdgeIntAttribute().setThis(dereference(self._edgeAttrs).attachInt(stdstring(name))), int)
 		elif ofType == float:
@@ -1168,6 +1202,9 @@ cdef class Graph:
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
 
+		if self._edgeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
+
 		if ofType == int:
 			return EdgeAttribute(EdgeIntAttribute().setThis(dereference(self._edgeAttrs).getInt(stdstring(name))), int)
 		elif ofType == float:
@@ -1192,6 +1229,8 @@ cdef class Graph:
 		"""
 		if not isinstance(name, str):
 			raise Exception("Attribute name has to be a string")
+		if self._edgeAttrs is NULL:
+			raise RuntimeError("this graph does not carry attributes; attach them to the base graph")
 		dereference(self._edgeAttrs).detach(stdstring(name))
 
 	# Mutable operations (require underlying _GraphW)
@@ -1504,6 +1543,205 @@ cdef class Graph:
 		"""
 		dereference(self._mutable()).setWeight(u, v, w)
 		return self
+
+cdef class InducedSubgraphView:
+
+	"""
+	InducedSubgraphView(base)
+	InducedSubgraphView(base, nodes)
+
+	The subgraph of `base` induced by a set of nodes, without materializing it.
+
+	Nodes are added and removed in batches; the edges are those of `base` with both endpoints in
+	the subset, recomputed on each traversal rather than stored. Only the operations that a
+	:class:`Graph` cannot express live here -- every read goes through :meth:`asGraph`.
+
+	Non-owning: `base` is kept alive by this object and by any graph handed out by
+	:meth:`asGraph`, but the view never copies it. Node ids are `base`'s.
+
+	Parameters
+	----------
+	base : networkit.Graph
+		The graph to view. May not itself be a view.
+	nodes : iterable of int, optional
+		Initial subset, given as base-graph ids. Ids absent from the base graph raise.
+	"""
+
+	cdef shared_ptr[_InducedSubgraphViewW] _wv  # set exactly when the base is writable
+	cdef shared_ptr[_InducedSubgraphViewR] _rv  # set exactly when the base is CSR-backed
+	cdef object _base
+
+	def __cinit__(self, Graph base not None, nodes=None):
+		cdef vector[node] cnodes
+		# The only place that branches on which concrete graph a Graph holds: the view's
+		# constructors take a concrete graph, so that a view of a view cannot be built.
+		if base._w is not NULL:
+			self._wv = make_shared[_InducedSubgraphViewW](dereference(base._w))
+		elif base._r is not NULL:
+			self._rv = make_shared[_InducedSubgraphViewR](dereference(base._r))
+		else:
+			raise TypeError("cannot induce a view on a view")
+		if nodes is not None:
+			cnodes = list(nodes)
+			self._addNodes(cnodes)
+		self._base = base
+
+	def __repr__(self):
+		if self._wv:
+			return "networkit.InducedSubgraphView(n={0}, m={1})".format(
+				dereference(self._wv).numberOfNodes(), dereference(self._wv).numberOfEdges())
+		return "networkit.InducedSubgraphView(n={0}, m={1})".format(
+			dereference(self._rv).numberOfNodes(), dereference(self._rv).numberOfEdges())
+
+	@property
+	def base(self):
+		"""
+		The graph being viewed.
+		"""
+		return self._base
+
+	def numberOfNodes(self):
+		if self._wv:
+			return dereference(self._wv).numberOfNodes()
+		return dereference(self._rv).numberOfNodes()
+
+	def numberOfEdges(self):
+		if self._wv:
+			return dereference(self._wv).numberOfEdges()
+		return dereference(self._rv).numberOfEdges()
+
+	def hasNode(self, node u):
+		"""
+		hasNode(u)
+
+		Returns whether `u`, given as a base-graph id, is in the subset.
+		"""
+		if self._wv:
+			return dereference(self._wv).hasNode(u)
+		return dereference(self._rv).hasNode(u)
+
+	def degree(self, node u):
+		"""
+		degree(u)
+
+		The number of the induced neighbors of `u`.
+		"""
+		if self._wv:
+			return dereference(self._wv).degree(u)
+		return dereference(self._rv).degree(u)
+
+	cdef _addNodes(self, vector[node] cnodes):
+		if self._wv:
+			dereference(self._wv).addNodes(cnodes)
+		else:
+			dereference(self._rv).addNodes(cnodes)
+
+	def addNode(self, node u):
+		"""
+		addNode(u)
+
+		Add one node, given as a base-graph id, to the subset.
+
+		Parameters
+		----------
+		u : int
+			A node of the base graph. Raises if absent from the base graph; ignored if already
+			present.
+		"""
+		cdef vector[node] cnodes
+		cnodes.push_back(u)
+		self._addNodes(cnodes)
+		return self
+
+	def addNodes(self, nodes):
+		"""
+		addNodes(nodes)
+
+		Add nodes, given as base-graph ids, to the subset.
+
+		Parameters
+		----------
+		nodes : iterable of int
+			Nodes of the base graph. Raises if any id is absent from the base graph; already
+			present ids are ignored.
+		"""
+		cdef vector[node] cnodes = list(nodes)
+		self._addNodes(cnodes)
+		return self
+
+	def removeNode(self, node u):
+		"""
+		removeNode(u)
+
+		Remove one node, given as a base-graph id, from the subset. Ignored if not present.
+		"""
+		self.removeNodes([u])
+		return self
+
+	def removeNodes(self, nodes):
+		"""
+		removeNodes(nodes)
+
+		Remove nodes, given as base-graph ids, from the subset. Absent ids are ignored.
+		"""
+		cdef vector[node] cnodes = list(nodes)
+		if self._wv:
+			dereference(self._wv).removeNodes(cnodes)
+		else:
+			dereference(self._rv).removeNodes(cnodes)
+		return self
+
+	def getNodeSubset(self):
+		"""
+		getNodeSubset()
+
+		Returns
+		-------
+		list(int)
+			The subset, always as base-graph ids, in ascending order.
+		"""
+		if self._wv:
+			return dereference(self._wv).getNodeSubset()
+		return dereference(self._rv).getNodeSubset()
+
+	def asGraph(self):
+		"""
+		asGraph()
+
+		Returns
+		-------
+		networkit.Graph
+			A read-only graph reading through this view. Reflects later changes to the subset;
+			attempting to modify it raises RuntimeError.
+
+		Notes
+		-----
+		:meth:`Graph.iterEdges` and :meth:`Graph.iterEdgesWeights` work but are slow: they step
+		each neighborhood by index, which recomputes the induced neighborhood per step. Iterate
+		nodes and their neighbors, or use :meth:`realize`, when iterating every edge matters.
+		"""
+		cdef Graph G = Graph.__new__(Graph)
+		return G._seatV(self._wv, self._rv, self._base)
+
+	def realize(self, bool_t compact=False):
+		"""
+		realize(compact=False)
+
+		Materialize an equivalent graph, copying the induced edges out of the base graph.
+
+		Parameters
+		----------
+		compact : bool, optional
+			Whether the result has ids 0..n-1 rather than the base ids. Default: False
+
+		Returns
+		-------
+		networkit.Graph
+			A writable graph holding its own copy of the induced edges.
+		"""
+		if self._wv:
+			return Graph().setThisFromGraphW(dereference(self._wv).realize(compact))
+		return Graph().setThisFromGraphW(dereference(self._rv).realize(compact))
 
 cdef class GraphW:
 	"""

--- a/networkit/graph.pyx
+++ b/networkit/graph.pyx
@@ -90,10 +90,12 @@ cdef class Graph:
 		# Python object alive keeps the C++ graph alive with it.
 		self._base = base
 		if wv:
-			self._handle = refGraphVW(dereference(wv))
+			# The view carries its own embedded handle, so this binds to storage the view owns
+			# rather than to a temporary.
+			self._handle = dereference(wv).asGraph()
 			self._owner = nk_erase[_InducedSubgraphViewW](wv)
 		else:
-			self._handle = refGraphVR(dereference(rv))
+			self._handle = dereference(rv).asGraph()
 			self._owner = nk_erase[_InducedSubgraphViewR](rv)
 		# Views carry no attribute maps of their own.
 		self._nodeAttrs = NULL

--- a/networkit/test/test_induced_subgraph_view.py
+++ b/networkit/test/test_induced_subgraph_view.py
@@ -1,0 +1,115 @@
+import unittest
+
+import networkit as nk
+
+
+class TestInducedSubgraphView(unittest.TestCase):
+	def setUp(self):
+		# The house graph plus a self-loop on node 0, matching the C++ fixture:
+		# edges 3-1, 1-0, 0-2, 2-1, 1-4, 4-3, 3-2, 2-4 in that order, then the loop.
+		self.base = nk.graph.Graph(n=5, weighted=True)
+		w = 1.0
+		for u, v in [(3, 1), (1, 0), (0, 2), (2, 1), (1, 4), (4, 3), (3, 2), (2, 4)]:
+			self.base.addEdge(u, v, w, addMissing=True)
+			w += 1.0
+		self.base.addEdge(0, 0)
+
+	def testViewMatchesSubgraphFromNodes(self):
+		subset = [1, 2, 3, 4]
+		view = nk.graph.InducedSubgraphView(self.base, subset).asGraph()
+		reference = nk.graphtools.subgraphFromNodes(self.base, subset, compact=False)
+
+		self.assertEqual(reference.numberOfNodes(), view.numberOfNodes())
+		self.assertEqual(reference.numberOfEdges(), view.numberOfEdges())
+		self.assertEqual(reference.numberOfSelfLoops(), view.numberOfSelfLoops())
+		self.assertAlmostEqual(reference.totalEdgeWeight(), view.totalEdgeWeight())
+
+		for u in subset:
+			self.assertEqual(sorted(reference.iterNeighbors(u)), sorted(view.iterNeighbors(u)))
+			self.assertEqual(
+				sorted(view.iterNeighborsWeights(u)), sorted(reference.iterNeighborsWeights(u))
+			)
+
+	def testReflectsMembershipEdits(self):
+		view = nk.graph.InducedSubgraphView(self.base)
+		backed = view.asGraph()
+
+		view.addNodes([1, 3])
+		self.assertEqual([1, 3], view.getNodeSubset())
+		self.assertEqual(1, backed.numberOfEdges()) # only 3-1 spans the subset
+		self.assertTrue(backed.hasEdge(1, 3))
+
+		view.addNode(4)
+		self.assertEqual(3, backed.numberOfEdges())
+
+		view.removeNodes([1])
+		self.assertEqual(1, backed.numberOfEdges())
+		self.assertFalse(backed.hasNode(1))
+
+	def testDegreesAndWeights(self):
+		view = nk.graph.InducedSubgraphView(self.base, [1, 2, 3, 4]).asGraph()
+		self.assertEqual(3, view.degree(1))
+		self.assertEqual(6, view.numberOfEdges())
+		self.assertAlmostEqual(31.0, view.totalEdgeWeight())
+		self.assertFalse(view.hasNode(0))
+
+	def testRunsExistingAlgorithmUnchanged(self):
+		subset = [1, 2, 3, 4]
+		view = nk.graph.InducedSubgraphView(self.base, subset).asGraph()
+		reference = nk.graphtools.subgraphFromNodes(self.base, subset, compact=False)
+
+		kcore = nk.centrality.CoreDecomposition(view)
+		kcore.run()
+		referenceKcore = nk.centrality.CoreDecomposition(reference)
+		referenceKcore.run()
+
+		for u in subset:
+			self.assertEqual(referenceKcore.score(u), kcore.score(u))
+
+	def testOverCSRBase(self):
+		base = nk.graph.Graph.fromCSR(5, False, [1, 2, 0, 2, 3, 4, 0, 1, 3, 4, 1, 2, 4, 1, 2, 3], [0, 2, 6, 10, 13, 16])
+		view = nk.graph.InducedSubgraphView(base, [1, 2, 3]).asGraph()
+		self.assertEqual(3, view.numberOfNodes())
+		self.assertEqual(3, view.numberOfEdges())
+
+	def testRejectsViewAsBase(self):
+		view = nk.graph.InducedSubgraphView(self.base, [1, 2])
+		with self.assertRaises(TypeError):
+			nk.graph.InducedSubgraphView(view.asGraph())
+
+	def testRejectsUnknownNodes(self):
+		with self.assertRaises(RuntimeError):
+			nk.graph.InducedSubgraphView(self.base, [99])
+
+	def testRejectsAttributesOnBackedGraph(self):
+		backed = nk.graph.InducedSubgraphView(self.base, [1, 2]).asGraph()
+		with self.assertRaises(RuntimeError):
+			backed.attachNodeAttribute("id", int)
+		with self.assertRaises(RuntimeError):
+			backed.attachEdgeAttribute("weight", float)
+
+	def testRejectsMutationOfBackedGraph(self):
+		backed = nk.graph.InducedSubgraphView(self.base, [1, 2]).asGraph()
+		with self.assertRaises(RuntimeError):
+			backed.addEdge(1, 2)
+		with self.assertRaises(RuntimeError):
+			backed.removeNode(1)
+
+	def testRealizeCopiesOut(self):
+		view = nk.graph.InducedSubgraphView(self.base, [1, 2, 3, 4])
+		materialized = view.realize(compact=False)
+		self.assertTrue(materialized.isWeighted())
+		self.assertEqual(6, materialized.numberOfEdges())
+		# the copy is independent of later membership edits
+		view.removeNodes([1])
+		self.assertEqual(6, materialized.numberOfEdges())
+
+	def testCompactRealizeHasDenseIds(self):
+		view = nk.graph.InducedSubgraphView(self.base, [2, 4])
+		materialized = view.realize(compact=True)
+		self.assertEqual(2, materialized.numberOfNodes())
+		self.assertEqual(2, materialized.upperNodeIdBound())
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "cython>=3.1.0",
+  "cython>=3.1.0,<3.3",
   "scipy",
   "numpy",
   "pyarrow==25.0.0",
@@ -60,7 +60,7 @@ addopts = ["--ignore=extlibs"]
 
 [build-system]
 requires = [
-  "cython>=3.1.0",
+  "cython>=3.1.0,<3.3",
   "numpy",
   "setuptools",
   "wheel"


### PR DESCRIPTION
## Summary

Reattempt of #43 (issue #39) on top of the graph-concepts rework, plus the first task it unblocked: making the existing zero-copy views first-class `GraphLike` types.

### 1. CoarsenedGraphView implements GraphLike

* Declares the missing primitives: `numberOfSelfLoops()` and `outNeighbors<Weighted>(u)` / `inNeighbors<Weighted>(u)` returning the on-demand aggregated neighborhood (one entry per adjacent supernode, summed weight). Node ids are dense, so the view pins `alwaysContiguousNodeIds = true`.
* Replaces its hand-rolled `forEdges` / `forNeighborsOf` / `weightedDegree` / `hasEdge` / `weight` bodies with thin forwarders to the free operations in `GraphIterationOps.hpp` (the same pattern GraphR/GraphW use), which also makes `parallelForEdges`, `parallelSumForEdges`, ... available to its users for free.
* Pinned with `static_assert(GraphLike<CoarsenedGraphView>)`.

**Bug fix found while testing:** `computeNeighbors` walked both endpoints' adjacency of every internal undirected edge and summed its weight twice into the supernode's self-loop block. It now counts each internal edge once, mirroring exactly the aggregation rule of the module's reference implementation (`ParallelPartitionCoarsening::aggregateEdgeWeights`).

### 2. InducedSubgraphView, reimplemented on the concept

Unlike #43, which subclassed the old virtual `Graph`, `InducedSubgraphView<BaseGraph>` is a header-only template over **any** `GraphLike` base -- `GraphR`, `GraphW`, `CoarsenedGraphView`, or another induced view -- and keeps base node ids.

* Batch `addNodes` / `removeNodes` maintain induced degrees, edge count and self-loop count incrementally while the batch is applied, keeping every GraphLike primitive O(1).
* Neighborhoods are never materialized: each range filters the base adjacency on the fly, so the footprint is one presence flag plus one or two degree counters per base node.
* Carries over the old attempt's API surface: single-node conveniences, `frontier()`, `realize(compact)` into an owned `GraphW`.

### Supporting changes

* `ReferenceGraph` (the type-erased `Graph`) gained `outNeighbors<W>` / `inNeighbors<W>`, so a type-erased handle itself satisfies `GraphLike`.
* The ops layer's `hasEdge` now bisects only when the neighborhood payload actually orders against a bare node (pair-carrying neighborhoods fall back to the scan), and `weight` handles unweighted graphs instead of reading a null weight array.

## Testing

* New `InducedSubgraphViewGTest` (12 tests): construction, degree/counter bookkeeping against independent ground truth, weighted neighborhoods, batch add/remove incl. shuffled batches with duplicates, directed in/out counters, frontier, `realize` vs `GraphTools::subgraphFromNodes`, free operations over the view, view-over-view composition, a read-only GraphR base, and a randomized Erdős–Rényi sweep.
* New `CoarsenedGraphViewGTest` (7 tests): singleton-partition identity, aggregated weights/degrees/loops on a hand-computed partition, layered coarsening vs. composed partition, free operations over the view, induced-view-over-coarsened-view composition, partition compaction, mapping accessors.
* Full canonical C++ suite (`networkit_tests -t`): 1890 tests ran, 1882 passed, 8 skipped, 0 failed.
